### PR TITLE
Adjust hero layout and image

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -12491,3 +12491,33 @@ body {
   }
 }
 
+/* ==== Overrides for profile image size and shape ==== */
+.profile {
+  border-radius: 50%;
+  max-width: 20rem;
+  max-height: 20rem;
+}
+.profile .profile-img {
+  border-radius: 50%;
+  width: 100%;
+  height: auto;
+}
+@media (min-width: 768px) {
+  .profile {
+    max-width: 22rem;
+    max-height: 22rem;
+  }
+}
+@media (min-width: 992px) {
+  .profile {
+    max-width: 25rem;
+    max-height: 25rem;
+  }
+}
+@media (min-width: 1200px) {
+  .profile {
+    max-width: 28rem;
+    max-height: 28rem;
+  }
+}
+

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
@@ -245,7 +245,7 @@
         <header class="py-5">
             <div class="container px-5 pb-5">
                 <div class="row gx-5 align-items-center">
-                    <div class="col-xxl-5">
+                    <div class="col-xxl-5 order-2 order-lg-1">
                         <!-- Header text content-->
                         <div class="text-center text-xxl-start">
                             <div class="badge bg-gradient-primary-to-secondary text-white mb-4">
@@ -264,11 +264,11 @@
                             </div>
                         </div>
                     </div>
-                    <div class="col-xxl-7">
+                    <div class="col-xxl-7 order-1 order-lg-2">
                         <!-- Header profile picture-->
                         <div class="d-flex justify-content-center mt-5 mt-xxl-0">
                             <div class="profile bg-gradient-primary-to-secondary">
-                                <img class="profile-img" src="assets/indexpic.png" alt="..." />
+                                <img class="profile-img" src="assets/indexpic.png" alt="Retrato de Rick Grisales" loading="lazy" />
                                 <!-- SVG decoraciones (dots) -->
                                 <div class="dots-1">
                                     <!-- Contenido SVG omitido para ahorrar espacio -->


### PR DESCRIPTION
## Summary
- shrink hero profile image
- prioritize layout order on small screens
- add alt text and lazy loading for the hero image

## Testing
- `node tests/word-cycle.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684744b0caac8324a7fd846124e3df27