### PR TITLE
Refactor about section

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -12491,3 +12491,28 @@ body {
   }
 }
 
+/* ----- About narrative section ----- */
+#about-narrative {
+  border-left: 2px solid var(--muted-text-color);
+  padding-left: 1rem;
+}
+
+.about-block {
+  margin-bottom: 2.5rem;
+}
+
+.about-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.about-block p {
+  line-height: 1.6;
+  margin-bottom: 0;
+}
+
+.about-block:last-child {
+  margin-bottom: 0;
+}
+

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/resume.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/resume.html
@@ -162,16 +162,21 @@
             </div>
             <div class="row gx-5 justify-content-center">
                 <div class="col-lg-11 col-xl-9 col-xxl-8">
-                   <!-- About Me Section -->
-<section>
-    <h2 class="text-primary fw-bolder mb-4">Un poco sobre mí :)</h2>
-    <div class="card shadow border-0 rounded-4 mb-5">
-        <div class="card-body p-5">
-        <div>Nací en España, pero crecí en Colombia, donde aprendí a mirar el mundo con ojos curiosos y donde la sensibilidad y la resiliencia se convirtieron en mis mayores acompañantes vitales. Desde muy joven encontré en el lenguaje una forma de entender la realidad y, sobre todo, de transformarla; son mis matemáticas. Por eso escribo: para pensar, para cuestionar y, a veces, para crear un poco de belleza. Me apasiona la relación entre cultura, sociedad y lenguaje, y he orientado mi formación y experiencia hacia el periodismo, la escritura crítica y la comunicación con conciencia, colectiva y, sobre todo, empática.</div>
-        
-        <div>Vivo solo desde que soy menor de edad, lo que me ha enseñado a ser responsable, independiente y a cultivar la introspección como una herramienta de creación y automejora. Amo las metáforas porque permiten decir lo que no siempre se puede explicar, o explicar aquello que solo se entiende desde lo poético. Creo en el poder de las palabras para conectar, sanar y también para hacer pensar. Por eso, cada proyecto que emprendo —ya sea académico, periodístico o creativo— nace de una pregunta, de mi neurodivergencia, y busca, <strong>siempre</strong>, aportar hacia un crecimiento comunitario.</div>        </div>
-    </div>
-</section>
+                    <!-- About Me Section -->
+                    <section id="about-narrative" class="my-5">
+                        <div class="about-block" data-aos="fade-up">
+                            <h3 class="about-title">What taught me to see differently</h3>
+                            <p>I was born in Spain but grew up in Colombia. I was raised between two languages, two ways of naming the same thing, and I quickly learned that there’s never just one way of understanding the world. That’s where my fascination with language began: with how it builds, and how it can either wound or embrace.</p>
+                        </div>
+                        <div class="about-block" data-aos="fade-up">
+                            <h3 class="about-title">Writing was never a choice</h3>
+                            <p>I don’t remember when I started writing — but I do remember why I kept going: to avoid falling silent in the face of what hurt, to invent meaning where there was none. Over time, I realized writing could also be a way to think, to question, to transform. A way to translate the unspoken — not with answers, but with better questions.</p>
+                        </div>
+                        <div class="about-block" data-aos="fade-up">
+                            <h3 class="about-title">It all begins with a question</h3>
+                            <p>Every project I take on begins there: with a question that won’t stay quiet. Whether it’s academic, journalistic, or creative, I want my work to be in conversation with reality — but also to unsettle it a little. And deep down, I want it to resemble who I am: curious, critical, sensitive. And fully convinced that language can — and should — be a tool for empathy.</p>
+                        </div>
+                    </section>
                     <!-- Experience Section-->
                     <section>
                         <div class="d-flex align-items-center justify-content-between mb-4">
@@ -314,6 +319,11 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Core theme JS-->
     <script src="js/scripts.js"></script>
+    <!-- AOS (Animate On Scroll) JS -->
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <script>
+        AOS.init();
+    </script>
     <!-- Theme toggle button -->
     <button id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
         <span id="theme-icon">🌙</span>


### PR DESCRIPTION
## Summary
- redesign "About Me" on resume page with three narrative blocks
- add AOS scripts to enable fade animations
- style the new blocks in CSS

## Testing
- `node tests/word-cycle.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6861cbff5fe08324b41c3b292ecccb0b