### PR TITLE
Set site to permanent dark theme

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/arte-naturaleza.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/arte-naturaleza.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es" data-theme="">
+<html lang="es" data-theme="dark">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -49,7 +49,6 @@
         }
 
         /* Estilo del botón de cambio de tema */
-        .theme-toggle {
             position: fixed;
             top: 1.5rem;
             right: 1.5rem;
@@ -67,7 +66,6 @@
             justify-content: center;
         }
         @media (max-width: 767px) {
-            .theme-toggle {
                 top: 4rem;
                 right: 1rem;
                 width: 32px;
@@ -133,7 +131,6 @@
             <a class="navbar-brand" href="index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
-            </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
                     <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
@@ -211,12 +208,6 @@
     </div>
 </footer>
 
-<!-- Theme toggle button -->
-<button id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
-    <span id="theme-icon">🌙</span>
-</button>
-<!-- Dark mode script -->
-<script src="js/dark-mode.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/contact.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/contact.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="">
+<html lang="en" data-theme="dark">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
@@ -54,7 +54,6 @@
         }
 
         /* Estilo del botón de cambio de tema */
-        .theme-toggle {
             position: fixed;
             top: 1.5rem;
             right: 1.5rem;
@@ -72,7 +71,6 @@
             justify-content: center;
         }
         @media (max-width: 767px) {
-            .theme-toggle {
                 top: 4rem;
                 right: 1rem;
                 width: 32px;
@@ -128,7 +126,6 @@
         <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
             <div class="container px-5">
                 <a class="navbar-brand" href="index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
                         <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
@@ -178,7 +175,6 @@
                                 <input type="hidden" name="_captcha" value="false">
                                 <!-- Submit Button -->
                                 <div class="d-grid">
-                                    <button class="btn btn-primary btn-lg" type="submit">Enviar</button>
                                 </div>
                             </form>
                         </div>
@@ -202,12 +198,6 @@
             </div>
         </div>
     </footer>
-    <!-- Theme toggle button -->
-    <button id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
-        <span id="theme-icon">🌙</span>
-    </button>
-    <!-- Dark mode script -->
-    <script src="js/dark-mode.js"></script>
     <!-- Bootstrap core JS-->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Core theme JS-->

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/gracias.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/gracias.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="">
+<html lang="en" data-theme="dark">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
@@ -50,7 +50,6 @@
         }
 
         /* Estilo del botón de cambio de tema */
-        .theme-toggle {
             position: fixed;
             top: 1.5rem;
             right: 1.5rem;
@@ -68,7 +67,6 @@
             justify-content: center;
         }
         @media (max-width: 767px) {
-            .theme-toggle {
                 top: 4rem;
                 right: 1rem;
                 width: 32px;
@@ -125,7 +123,6 @@
                 <a class="navbar-brand" href="index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
-                </button>
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
                         <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
@@ -176,11 +173,5 @@
     <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="js/scripts.js"></script>
-    <!-- Theme toggle button -->
-    <button id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
-        <span id="theme-icon">🌙</span>
-    </button>
-    <!-- Dark mode script -->
-    <script src="js/dark-mode.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="">
+<html lang="en" data-theme="dark">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
@@ -61,7 +61,6 @@
         }
 
         /* Estilo del botón de cambio de tema */
-        .theme-toggle {
             position: fixed;
             top: 1.5rem;
             right: 1.5rem;
@@ -79,7 +78,6 @@
             justify-content: center;
         }
         @media (max-width: 767px) {
-            .theme-toggle {
                 top: 4rem;
                 right: 1rem;
                 width: 32px;
@@ -229,7 +227,6 @@
                     data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
                     aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
-                </button>
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
                         <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
@@ -379,12 +376,6 @@
     <script>
         AOS.init();
     </script>
-    <!-- Theme toggle button -->
-    <button id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
-        <span id="theme-icon">🌙</span>
-    </button>
-    <!-- Dark mode script -->
-    <script src="js/dark-mode.js"></script>
     <!-- Word cycling script -->
     <script src="js/word-cycle.js"></script>
 

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/poder-mentira.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/poder-mentira.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es" data-theme="">
+<html lang="es" data-theme="dark">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -53,7 +53,6 @@
         }
 
         /* Estilo del botón de cambio de tema */
-        .theme-toggle {
             position: fixed;
             top: 1.5rem;
             right: 1.5rem;
@@ -71,7 +70,6 @@
             justify-content: center;
         }
         @media (max-width: 767px) {
-            .theme-toggle {
                 top: 4rem;
                 right: 1rem;
                 width: 32px;
@@ -169,7 +167,6 @@
             <a class="navbar-brand" href="index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
-            </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
                     <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
@@ -240,12 +237,6 @@
     </div>
 </footer>
 
-<!-- Theme toggle button -->
-<button id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
-    <span id="theme-icon">🌙</span>
-</button>
-<!-- Dark mode script -->
-<script src="js/dark-mode.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/projects.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/projects.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="">
+<html lang="en" data-theme="dark">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
@@ -50,7 +50,6 @@
         }
 
         /* Estilo del botón de cambio de tema */
-        .theme-toggle {
             position: fixed;
             top: 1.5rem;
             right: 1.5rem;
@@ -68,7 +67,6 @@
             justify-content: center;
         }
         @media (max-width: 767px) {
-            .theme-toggle {
                 top: 4rem;
                 right: 1rem;
                 width: 32px;
@@ -170,7 +168,6 @@
     <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
         <div class="container px-5">
             <a class="navbar-brand" href="index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
                     <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
@@ -255,11 +252,5 @@
 </footer>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="js/scripts.js"></script>
-<!-- Theme toggle button -->
-<button id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
-    <span id="theme-icon">🌙</span>
-</button>
-<!-- Dark mode script -->
-<script src="js/dark-mode.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/resume.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/resume.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="">
+<html lang="en" data-theme="dark">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
@@ -56,7 +56,6 @@
         }
 
         /* Estilo del botón de cambio de tema */
-        .theme-toggle {
             position: fixed;
             top: 1.5rem;
             right: 1.5rem;
@@ -74,7 +73,6 @@
             justify-content: center;
         }
         @media (max-width: 767px) {
-            .theme-toggle {
                 top: 4rem;
                 right: 1rem;
                 width: 32px;
@@ -144,7 +142,6 @@
                         data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
                         aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
-                </button>
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
                         <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
@@ -314,11 +311,5 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Core theme JS-->
     <script src="js/scripts.js"></script>
-    <!-- Theme toggle button -->
-    <button id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
-        <span id="theme-icon">🌙</span>
-    </button>
-    <!-- Dark mode script -->
-    <script src="js/dark-mode.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/rhip.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/rhip.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es" data-theme="">
+<html lang="es" data-theme="dark">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -47,7 +47,6 @@
         }
 
         /* Estilo del botón de cambio de tema */
-        .theme-toggle {
             position: fixed;
             top: 1.5rem;
             right: 1.5rem;
@@ -65,7 +64,6 @@
             justify-content: center;
         }
         @media (max-width: 767px) {
-            .theme-toggle {
                 top: 4rem;
                 right: 1rem;
                 width: 32px;
@@ -196,7 +194,6 @@
             <a class="navbar-brand" href="index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent">
                 <span class="navbar-toggler-icon"></span>
-            </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
                     <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
@@ -320,41 +317,8 @@
 <!-- Bootstrap core JS -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 
-<!-- SCRIPT PARA MODO OSCURO -->
-<script>
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const userTheme = localStorage.getItem('theme');
-    if (userTheme) {
-        document.documentElement.setAttribute('data-theme', userTheme);
-    } else if (prefersDark) {
-        document.documentElement.setAttribute('data-theme', 'dark');
-    }
-    function toggleTheme() {
-        const currentTheme = document.documentElement.getAttribute('data-theme');
-        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', newTheme);
-        localStorage.setItem('theme', newTheme);
-        updateIcon(newTheme);
-    }
-    function updateIcon(theme) {
-        const icon = document.getElementById('theme-icon');
-        if (!icon) return;
-        icon.textContent = theme === 'dark' ? '☀️' : '🌙';
-    }
-    document.addEventListener('DOMContentLoaded', () => {
-        const button = document.getElementById('theme-toggle');
-        if (button) {
-            button.addEventListener('click', toggleTheme);
-            const current = document.documentElement.getAttribute('data-theme') || 'light';
-            updateIcon(current);
-        }
-    });
-</script>
 
-<!-- BOTÓN DE TEMA -->
-<button id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
-    <span id="theme-icon">🌙</span>
-</button>
+
 
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/salomon.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/salomon.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es" data-theme="">
+<html lang="es" data-theme="dark">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -47,7 +47,6 @@
         }
 
         /* Estilo del botón de cambio de tema */
-        .theme-toggle {
             position: fixed;
             top: 1.5rem;
             right: 1.5rem;
@@ -65,7 +64,6 @@
             justify-content: center;
         }
         @media (max-width: 767px) {
-            .theme-toggle {
                 top: 4rem; /* Bajamos el botón en pantallas pequeñas para evitar solapamiento con el menú */
                 right: 1rem;
                 width: 32px;
@@ -180,7 +178,6 @@
             <a class="navbar-brand" href="index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent">
                 <span class="navbar-toggler-icon"></span>
-            </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
                     <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
@@ -267,53 +264,8 @@
 <!-- Bootstrap core JS -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 
-<!-- SCRIPT PARA MODO OSCURO -->
-<script>
-    // 1. Detecta si el sistema del usuario prefiere modo oscuro
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    // 2. Revisa si el usuario ya eligió un tema en 'localStorage'
-    const userTheme = localStorage.getItem('theme');
 
-    if (userTheme) {
-        // Si el usuario guardó 'dark' o 'light', lo aplicamos
-        document.documentElement.setAttribute('data-theme', userTheme);
-    } else if (prefersDark) {
-        // Si no hay preferencia guardada, pero el sistema es oscuro
-        document.documentElement.setAttribute('data-theme', 'dark');
-    }
 
-    // Alternar el tema (cuando se hace click en el botón)
-    function toggleTheme() {
-        const currentTheme = document.documentElement.getAttribute('data-theme');
-        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', newTheme);
-        localStorage.setItem('theme', newTheme);
-        updateIcon(newTheme);
-    }
-
-    // Actualizar el iconito según el tema
-    function updateIcon(theme) {
-        const icon = document.getElementById('theme-icon');
-        if (!icon) return;
-        icon.textContent = theme === 'dark' ? '☀️' : '🌙';
-    }
-
-    // Espera a que cargue el DOM para asociar el evento de click
-    document.addEventListener('DOMContentLoaded', () => {
-        const button = document.getElementById('theme-toggle');
-        if (button) {
-            button.addEventListener('click', toggleTheme);
-            // Sincroniza el icono actual
-            const current = document.documentElement.getAttribute('data-theme') || 'light';
-            updateIcon(current);
-        }
-    });
-</script>
-
-<!-- BOTÓN DE TEMA (arriba a la derecha) -->
-<button id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
-    <span id="theme-icon">🌙</span>
-</button>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove light/dark toggle controls
- default the site to dark theme on all pages

## Testing
- `node tests/word-cycle.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686248d24ecc8324a1e8f79d15a62b9d