### PR TITLE
Fix carousel arrow placement

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -12193,10 +12193,10 @@ body {
   box-shadow: none !important;
 }
 .swiper-button-prev {
-  left: 10px;
+  left: -25px;
 }
 .swiper-button-next {
-  right: 10px;
+  right: -25px;
 }
 .swiper-button-next:after,
 .swiper-button-prev:after {
@@ -12484,11 +12484,18 @@ body {
     font-size: 0.95rem;
   }
 
-  .swiper-button-next,
   .swiper-button-prev {
     width: 28px;
     height: 28px;
     top: 45%;
+    left: 5px;
+  }
+
+  .swiper-button-next {
+    width: 28px;
+    height: 28px;
+    top: 45%;
+    right: 5px;
   }
 }
 


### PR DESCRIPTION
## Summary
- move Swiper arrow buttons outward
- position arrows closer to slide edges on small screens

## Testing
- `node tests/word-cycle.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68643463c1b48324aee293ef3656d715