### PR TITLE
Fix carousel usability

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/contact.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/contact.html
@@ -126,6 +126,11 @@
         <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
             <div class="container px-5">
                 <a class="navbar-brand" href="index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
+                <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+                    data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
+                    aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
                         <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -12152,7 +12152,7 @@ body {
 
 /* Etiqueta de género */
 .genre-label {
-  color: #ff8a00 !important;
+  color: #FF7A00 !important;
   font-weight: bold !important;
   font-size: 1rem !important;
   margin-bottom: 7px;
@@ -12184,7 +12184,7 @@ body {
 .swiper-button-prev {
   background: none !important;
   border: none !important;
-  color: #ff8a00 !important;
+  color: #FF7A00 !important;
   width: 44px;
   height: 44px;
   top: 50%;
@@ -12201,7 +12201,7 @@ body {
 .swiper-button-next:after,
 .swiper-button-prev:after {
   font-size: 32px;
-  color: #ff8a00 !important;
+  color: #FF7A00 !important;
   font-weight: bold;
 }
 
@@ -12231,12 +12231,12 @@ body {
 
 .ver-todos-link {
   display: inline-block;
-  color: #ff8a00 !important;
+  color: #FF7A00 !important;
   text-decoration: underline !important;
   font-weight: 500;
   font-size: 1rem;
   padding: 8px 16px;
-  border-bottom: 2px solid #ff8a00 !important;
+  border-bottom: 2px solid #FF7A00 !important;
   transition: all 0.3s ease;
 }
 
@@ -12250,8 +12250,8 @@ body {
 
 /* Para modo oscuro */
 [data-theme="dark"] .ver-todos-link {
-  color: #ff8a00 !important;
-  border-bottom-color: #ff8a00 !important;
+  color: #FF7A00 !important;
+  border-bottom-color: #FF7A00 !important;
 }
 
 [data-theme="dark"] .ver-todos-link:hover {

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
@@ -179,16 +179,18 @@
       overflow: hidden;
       border-radius: 1.5rem;
       box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
+      width: 100%;
+      padding-top: 75%; /* 4:3 ratio */
+      display: block;
     }
     .project-card-preview img {
+      position: absolute;
+      inset: 0;
       width: 100%;
       height: 100%;
       object-fit: cover;
       transition: transform 0.3s ease;
       display: block;
-    }
-    .project-card-preview:hover img {
-      transform: scale(1.05);
     }
     .project-card-preview .overlay {
       position: absolute;
@@ -203,6 +205,9 @@
       opacity: 0;
       transition: opacity 0.3s ease;
     }
+    .project-card-preview:hover img {
+      transform: scale(1.05);
+    }
     .project-card-preview:hover .overlay {
       opacity: 1;
     }
@@ -214,6 +219,27 @@
     .project-card-preview p {
       color: #ccc;
       font-size: 0.9rem;
+    }
+
+    .project-swiper {
+      overflow: visible;
+    }
+    .swiper-button-next,
+    .swiper-button-prev {
+      color: #FF7A00 !important;
+      z-index: 20;
+    }
+    @media (min-width: 1280px) {
+      .swiper-button-prev { left: -60px; }
+      .swiper-button-next { right: -60px; }
+    }
+    @media (min-width: 768px) and (max-width: 1279px) {
+      .swiper-button-prev { left: -40px; }
+      .swiper-button-next { right: -40px; }
+    }
+    @media (max-width: 767px) {
+      .swiper-button-next,
+      .swiper-button-prev { display: none; }
     }
     @media (max-width: 767px) {
       .project-card-preview {
@@ -302,7 +328,7 @@
                     </h2>
                 </div>
 
-                <div class="swiper project-swiper">
+                <div class="swiper project-swiper" role="region" aria-label="Carrusel de proyectos" aria-live="polite">
                     <div class="swiper-wrapper">
                         <div class="swiper-slide">
                             <a href="arte-naturaleza.html" class="project-card-preview">
@@ -341,8 +367,8 @@
                             </a>
                         </div>
                     </div>
-                    <div class="swiper-button-prev"></div>
-                    <div class="swiper-button-next"></div>
+                    <div class="swiper-button-prev" aria-label="Anterior"></div>
+                    <div class="swiper-button-next" aria-label="Siguiente"></div>
                 </div>
 
                 <div class="ver-todos-container mt-4">
@@ -431,6 +457,10 @@
     <script>
         const projectSwiper = new Swiper('.project-swiper', {
             loop: true,
+            autoplay: {
+                delay: 4000,
+                disableOnInteraction: false
+            },
             navigation: {
                 nextEl: '.swiper-button-next',
                 prevEl: '.swiper-button-prev',

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/projects.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/projects.html
@@ -148,12 +148,16 @@
             object-fit: cover;
         }
         @media (max-width: 768px) {
-            .project-card {
+            .project-card-horizontal {
                 flex-direction: column;
             }
             .project-image-wrapper {
                 flex: none;
                 width: 100%;
+                order: -1;
+            }
+            .project-image {
+                height: auto;
             }
         }
         .footer a {
@@ -170,6 +174,11 @@
     <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
         <div class="container px-5">
             <a class="navbar-brand" href="index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+                data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
+                aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
                     <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>


### PR DESCRIPTION
## Summary
- keep a 4:3 ratio for carousel project cards
- color navigation arrows and remove them on small screens
- change "Ver todos" link to the corporate orange
- autoplay the project carousel

## Testing
- `node tests/word-cycle.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6873dc56b520832485fa1c9e8ca9cd4c