### PR TITLE
Limit project carousel to three visible slides

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
@@ -224,13 +224,6 @@
     .project-swiper {
       overflow: hidden;
     }
-    @media (min-width: 768px) {
-      .project-swiper {
-        overflow: visible;
-      }
-    }
-      overflow: visible;
-    }
       
     .swiper-button-next,
     .swiper-button-prev {
@@ -476,16 +469,8 @@
                 nextEl: '.project-nav-next',
                 prevEl: '.project-nav-prev',
             },
-            slidesPerView: 1,
-            spaceBetween: 20,
-            breakpoints: {
-                768: {
-                    slidesPerView: 2
-                },
-                992: {
-                    slidesPerView: 3
-                }
-            }
+            slidesPerView: 3,
+            spaceBetween: 20
         });
     </script>
     <!-- Word cycling script -->


### PR DESCRIPTION
## Summary
- keep overflow hidden on project swiper container
- ensure project carousel always shows only three slides

## Testing
- `node tests/word-cycle.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68744908c54c8324a3eb685cd8569a5f