### PR TITLE
Add writer's diary section and navigation

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/arte-naturaleza.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/arte-naturaleza.html
@@ -137,6 +137,7 @@
                     <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
                     <li class="nav-item"><a class="nav-link" href="resume.html">Resumen - CV</a></li>
                     <li class="nav-item"><a class="nav-link" href="projects.html">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="diario/">Diario de un escritor perdido</a></li>
                     <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
                 </ul>
             </div>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/contact.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/contact.html
@@ -136,6 +136,7 @@
                         <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
                         <li class="nav-item"><a class="nav-link" href="resume.html">Resumen - CV</a></li>
                         <li class="nav-item"><a class="nav-link" href="projects.html">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="diario/">Diario de un escritor perdido</a></li>
                         <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
                     </ul>
                 </div>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diario/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diario/index.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="es" data-theme="dark">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="description" content="Notas breves y pensamientos de Rick Grisales" />
+    <meta name="author" content="Rick Grisales" />
+    <title>Diario de un escritor perdido - Rick Grisales</title>
+    <link rel="canonical" href="/diario/" />
+    <link rel="icon" type="image/x-icon" href="../assets/orange.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css" rel="stylesheet" />
+    <link href="../css/styles.css" rel="stylesheet" />
+    <style>
+        :root {
+            --bg-color: #ffffff;
+            --text-color: #000000;
+            --muted-text-color: #6c757d;
+            --nav-link-color: #000000;
+            --section-bg-light: #f8f9fa;
+            --btn-outline-border: #000000;
+            --caption-color: #6c757d;
+        }
+        [data-theme="dark"] {
+            --bg-color: #121212;
+            --text-color: #ffffff;
+            --muted-text-color: #adb5bd;
+            --nav-link-color: #ffa94d;
+            --section-bg-light: #1e1e1e;
+            --btn-outline-border: #ffffff;
+            --caption-color: #adb5bd;
+        }
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            transition: background-color 0.3s, color 0.3s;
+        }
+        .navbar, .footer { background-color: var(--bg-color) !important; }
+        .bg-light { background-color: var(--section-bg-light) !important; }
+        .nav-link { color: var(--nav-link-color) !important; }
+        .text-muted { color: var(--muted-text-color) !important; }
+    </style>
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
+        <div class="container px-5">
+            <a class="navbar-brand" href="../index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
+                    <li class="nav-item"><a class="nav-link" href="../index.html">Home</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../resume.html">Resumen - CV</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../projects.html">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../diario/">Diario de un escritor perdido</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../contact.html">Contacto</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <main>
+        <header class="py-5">
+            <div class="container px-5">
+                <div class="text-center mb-5">
+                    <h1 class="display-5 fw-bolder"><span class="text-gradient d-inline">Diario de un escritor perdido</span></h1>
+                    <p class="lead fw-normal text-muted mb-4" id="diary-subtitle">Pensamientos sueltos en busca de hogar.</p>
+                    <div class="mx-auto" style="max-width: 400px;">
+                        <input type="search" id="diary-search" class="form-control" placeholder="Buscar..." aria-label="Buscar en el diario" />
+                    </div>
+                </div>
+            </div>
+        </header>
+
+        <section class="container px-5" id="diary-entries"></section>
+
+        <div class="text-center my-5">
+            <a class="btn btn-outline-dark px-4 py-2" href="../index.html">Volver al inicio</a>
+        </div>
+    </main>
+
+    <footer class="py-4 mt-auto footer">
+        <div class="container px-5">
+            <div class="row align-items-center justify-content-between flex-column flex-sm-row">
+                <div class="col-auto"><div class="small m-0">Copyright © Rick 2025</div></div>
+                <div class="col-auto">
+                    <a class="small" href="#!">Privacidad</a>
+                    <span class="mx-1">·</span>
+                    <a class="small" href="#!">Términos</a>
+                    <span class="mx-1">·</span>
+                    <a class="small" href="#!">Contacto</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="../js/scripts.js"></script>
+    <script src="../js/dark-mode.js"></script>
+    <script src="../js/diario-entries.js"></script>
+    <script src="../js/diario.js"></script>
+</body>
+</html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/gracias.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/gracias.html
@@ -129,6 +129,7 @@
                         <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
                         <li class="nav-item"><a class="nav-link" href="resume.html">Resumen - CV</a></li>
                         <li class="nav-item"><a class="nav-link" href="projects.html">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="diario/">Diario de un escritor perdido</a></li>
                         <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
                     </ul>
                 </div>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
@@ -274,6 +274,7 @@
                         <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
                         <li class="nav-item"><a class="nav-link" href="resume.html">Resumen - CV</a></li>
                         <li class="nav-item"><a class="nav-link" href="projects.html">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="diario/">Diario de un escritor perdido</a></li>
                         <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
                     </ul>
                 </div>
@@ -429,6 +430,14 @@
         </section>
 
 
+    <section class="py-5">
+        <div class="container px-5 text-center">
+            <h2 class="display-5 fw-bolder"><span class="text-gradient d-inline">Diario de un escritor perdido</span></h2>
+            <div id="diary-teaser" class="text-start mt-4"></div>
+            <a class="btn btn-outline-dark px-4 py-2 mt-4" href="diario/">Leer el diario completo</a>
+        </div>
+    </section>
+
     <!-- Footer-->
     <footer class="py-4 mt-auto">
         <div class="container px-5">
@@ -474,6 +483,8 @@
         });
     </script>
     <!-- Word cycling script -->
+    <script src="js/diario-entries.js"></script>
+    <script src="js/diario-teaser.js"></script>
     <script src="js/word-cycle.js"></script>
 
 </body>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diario-entries.js
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diario-entries.js
@@ -1,0 +1,24 @@
+const diaryEntries = [
+  {
+    id: '2024-05-01',
+    date: '2024-05-01',
+    title: 'Entre la bruma',
+    content: 'Desperté con la <em>sensación</em> de haber hablado en sueños.'
+  },
+  {
+    id: '2024-04-20',
+    date: '2024-04-20',
+    title: '',
+    content: 'Hay días en los que la ciudad respira por mí.'
+  },
+  {
+    id: '2024-03-15',
+    date: '2024-03-15',
+    title: 'Aprender a callar',
+    content: 'Silencio no es vacío, es <strong>promesa</strong>.'
+  }
+];
+
+if (typeof module !== 'undefined') {
+  module.exports = diaryEntries;
+}

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diario-teaser.js
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diario-teaser.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const teaser = document.getElementById('diary-teaser');
+  if (!teaser) return;
+  const latest = [...diaryEntries]
+    .sort((a, b) => new Date(b.date) - new Date(a.date))
+    .slice(0, 2);
+  latest.forEach(entry => {
+    const article = document.createElement('article');
+    if (entry.title) {
+      const h3 = document.createElement('h3');
+      h3.textContent = entry.title;
+      article.appendChild(h3);
+    }
+    const time = document.createElement('time');
+    time.dateTime = entry.date;
+    time.className = 'text-muted d-block mb-2';
+    time.textContent = new Date(entry.date).toLocaleDateString('es-ES', { day: 'numeric', month: 'short', year: 'numeric' });
+    article.appendChild(time);
+    const p = document.createElement('p');
+    const snippet = entry.content.length > 120 ? entry.content.substring(0, 120) + '…' : entry.content;
+    p.innerHTML = snippet;
+    article.appendChild(p);
+    teaser.appendChild(article);
+  });
+});

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diario.js
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diario.js
@@ -1,0 +1,51 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('diary-entries');
+  const search = document.getElementById('diary-search');
+  if (!container) return;
+
+  function render(list) {
+    container.innerHTML = '';
+    let currentMonth = '';
+    list.forEach(entry => {
+      const date = new Date(entry.date);
+      const monthLabel = date.toLocaleDateString('es-ES', { month: 'long', year: 'numeric' });
+      if (monthLabel !== currentMonth) {
+        const h2 = document.createElement('h2');
+        h2.textContent = monthLabel.charAt(0).toUpperCase() + monthLabel.slice(1);
+        container.appendChild(h2);
+        currentMonth = monthLabel;
+      }
+      const article = document.createElement('article');
+      const header = document.createElement('header');
+      if (entry.title) {
+        const h3 = document.createElement('h3');
+        h3.textContent = entry.title;
+        header.appendChild(h3);
+      }
+      const time = document.createElement('time');
+      time.dateTime = entry.date;
+      time.className = 'text-muted d-block mb-2';
+      time.textContent = date.toLocaleDateString('es-ES', { day: 'numeric', month: 'long', year: 'numeric' });
+      header.appendChild(time);
+      article.appendChild(header);
+      const p = document.createElement('p');
+      p.innerHTML = entry.content;
+      article.appendChild(p);
+      container.appendChild(article);
+    });
+  }
+
+  function filterEntries() {
+    const q = search.value.toLowerCase();
+    const filtered = diaryEntries.filter(e =>
+      (e.title && e.title.toLowerCase().includes(q)) ||
+      e.content.toLowerCase().includes(q)
+    );
+    const sorted = filtered.sort((a, b) => new Date(b.date) - new Date(a.date));
+    render(sorted);
+  }
+
+  diaryEntries.sort((a, b) => new Date(b.date) - new Date(a.date));
+  render(diaryEntries);
+  search.addEventListener('input', filterEntries);
+});

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/kali-uchis.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/kali-uchis.html
@@ -170,6 +170,7 @@
                     <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
                     <li class="nav-item"><a class="nav-link" href="resume.html">Resumen - CV</a></li>
                     <li class="nav-item"><a class="nav-link" href="projects.html">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="diario/">Diario de un escritor perdido</a></li>
                     <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
                 </ul>
             </div>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/poder-mentira.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/poder-mentira.html
@@ -173,6 +173,7 @@
                     <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
                     <li class="nav-item"><a class="nav-link" href="resume.html">Resumen - CV</a></li>
                     <li class="nav-item"><a class="nav-link" href="projects.html">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="diario/">Diario de un escritor perdido</a></li>
                     <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
                 </ul>
             </div>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/projects.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/projects.html
@@ -184,6 +184,7 @@
                     <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
                     <li class="nav-item"><a class="nav-link" href="resume.html">Resumen - CV</a></li>
                     <li class="nav-item"><a class="nav-link" href="projects.html">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="diario/">Diario de un escritor perdido</a></li>
                     <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
                 </ul>
             </div>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/resume.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/resume.html
@@ -180,6 +180,7 @@
                         <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
                         <li class="nav-item"><a class="nav-link" href="resume.html">Resumen - CV</a></li>
                         <li class="nav-item"><a class="nav-link" href="projects.html">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="diario/">Diario de un escritor perdido</a></li>
                         <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
                     </ul>
                 </div>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/salomon.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/salomon.html
@@ -184,6 +184,7 @@
                     <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
                     <li class="nav-item"><a class="nav-link" href="resume.html">Resumen - CV</a></li>
                     <li class="nav-item"><a class="nav-link" href="projects.html">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="diario/">Diario de un escritor perdido</a></li>
                     <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
## Summary
- add "Diario de un escritor perdido" page with searchable, grouped entries
- link diary from navigation and teaser on home page
- centralize diary entry data for automatic updates

## Testing
- `node tests/word-cycle.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbc84fdac8832480ec5a180366b281