### PR TITLE
Render diary entries as Markdown

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diario/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diario/index.html
@@ -22,6 +22,7 @@
             --section-bg-light: #f8f9fa;
             --btn-outline-border: #000000;
             --caption-color: #6c757d;
+            --bs-body-bg: var(--bg-color);
         }
         [data-theme="dark"] {
             --bg-color: #121212;
@@ -31,6 +32,7 @@
             --section-bg-light: #1e1e1e;
             --btn-outline-border: #ffffff;
             --caption-color: #adb5bd;
+            --bs-body-bg: var(--bg-color);
         }
         body {
             margin: 0;
@@ -47,7 +49,7 @@
     </style>
 </head>
 <body>
-    <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
+    <nav class="navbar navbar-expand-lg navbar-dark py-3">
         <div class="container px-5">
             <a class="navbar-brand" href="../index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -103,6 +105,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="../js/scripts.js"></script>
     <script src="../js/dark-mode.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="../js/diario-entries.js"></script>
     <script src="../js/diario.js"></script>
 </body>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
@@ -440,6 +440,7 @@
         });
     </script>
     <!-- Word cycling script -->
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="js/diario-entries.js"></script>
     <script src="js/diario-teaser.js"></script>
     <script src="js/word-cycle.js"></script>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diario-entries.js
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diario-entries.js
@@ -1,21 +1,109 @@
 const diaryEntries = [
   {
-    id: '2024-05-01',
-    date: '2024-05-01',
-    title: 'Entre la bruma',
-    content: 'Desperté con la <em>sensación</em> de haber hablado en sueños.'
-  },
-  {
-    id: '2024-04-20',
-    date: '2024-04-20',
-    title: '',
-    content: 'Hay días en los que la ciudad respira por mí.'
-  },
-  {
-    id: '2024-03-15',
-    date: '2024-03-15',
-    title: 'Aprender a callar',
-    content: 'Silencio no es vacío, es <strong>promesa</strong>.'
+    id: '2025-09-11',
+    date: '2025-09-11',
+    title: 'El rico es rico porque es rico',
+    content: `# El rico es rico porque es rico  
+
+> *“El capital genera más capital. El que ya tiene, siempre gana más. El resto apenas sobrevive.”*  
+
+---
+
+### Una conversación cualquiera  
+
+**Rick:** Si tengo 800 dólares en mi cuenta con un APY de 5%, ¿de cuánto es el incremento mensual?  
+
+**ChatGPT:** Al mes ganarías unos $3.33 en intereses.  
+
+**Rick:** ¿Y si fueran 100.000?  
+
+**ChatGPT:** Al mes ganas unos $416.67 en intereses. Al año ganas $5,000.00.  
+
+Ese simple cálculo se me quedó pegado como una verdad incómoda.  
+
+---
+
+### Llegar y chocar con el sistema  
+
+Hace poco llegué a este país y empecé a trabajar duro, muy duro; mis pies podrían contar mejor esta historia.  
+Tengo la suerte —o la desgracia— de ser un hombre blanco, regularizado, y eso me permitió conseguir empleo rápido.  
+No gano mucho, pero me alcanza para ir abonando las deudas que arrastro del camino académico.  
+
+Días atrás decidí abrir una cuenta de ahorros. Comparé bancos, tasas, APYs… buscando el famoso efecto bola de nieve.  
+Leí sobre crédito, sobre ahorro, sobre todo ese mundo que parece diseñado para quien ya tiene capital.  
+Al final entendí que, en números, la desigualdad no necesita teoría: se ve clarísima.  
+
+---
+
+### ¿En serio se sabe?  
+
+Lo obvio es lo más brutal.  
+Sí, todos sabemos que **el rico es rico porque es rico**, pero no todos lo sentimos en carne propia.  
+
+Cuando le conté mi descubrimiento a un amigo, me dijo:  
+> *“Ah, apenas descubres cómo funciona el mundo.”*  
+
+Y quizá tenía razón. Muchos pensarán que soy ingenuo, joven, inocente.  
+Pero hay una diferencia enorme entre **saber algo** y **sentirlo hasta que duela**.  
+
+---
+
+### Escenas de aquí  
+
+Aquí veo ancianos trabajando.  
+Aquí trabajo sin seguro médico.  
+Aquí la gente suplica a sus jefes que les den más horas, mientras los cuerpos se quiebran.  
+
+En España, en mis últimos trabajos, eran los jefes quienes casi nos rogaban hacer horas extras.  
+Aquí, en cambio, una señora me dice:  
+> *“Ay, Ricardo, quédese ahí, déjeme trabajar, que si no me van a quitar mis horas.”*  
+
+Cuando acaba su turno, sigue trabajando. Yo la regaño:  
+> *“Deja eso, ya vete a casa, no te están pagando; a mí sí, descansa.”*  
+
+Y aun así se queda.  
+
+¿Qué es esto?  
+
+---
+
+### Conversaciones cruzadas  
+
+Le contaba a un familiar que en España querían bajar la jornada laboral a 37,5 horas.  
+(La medida la tumbaron en el Congreso hoy).  
+
+Él, que lleva años acá y tiene buena vida sistemática, me preguntó:  
+—¿Quién gobierna en España?  
+—El Partido Socialista, le dije.  
+—No me digas más, ya con eso sé todo.  
+
+No hace falta añadir más.  
+No busco debate.  
+
+---
+
+### ¿Exagero?  
+
+¿Será que esto pasa solo en mi trabajo?  
+¿Será que exagero, que todo es una tontería?  
+¿Será el barrio, la ciudad, el país?  
+
+O quizá, simplemente, estoy dejando de ser crédulo y me estoy chocando otra vez con el mundo real.  
+
+---
+
+### Filosofía, ciencia, naturaleza  
+
+Cada día dimensiono más el sistema.  
+Y cada día estoy más convencido de que solo encontraremos un camino como especie cuando logremos **conectar la filosofía, la ciencia y la naturaleza**.  
+Porque al final son la misma cosa, aunque nos empeñemos en dividirlas.  
+
+---
+
+### Cierre  
+
+Poco más que decir de este texto raro, a medio camino entre desahogo y crónica.  
+Un número tan simple como un 5% me recordó que la vida no es solo matemática: es también sudor, cansancio, y la certeza amarga de que el rico es rico porque es rico.`
   }
 ];
 

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diario-teaser.js
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diario-teaser.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!teaser) return;
   const latest = [...diaryEntries]
     .sort((a, b) => new Date(b.date) - new Date(a.date))
-    .slice(0, 2);
+    .slice(0, 1);
   latest.forEach(entry => {
     const article = document.createElement('article');
     if (entry.title) {
@@ -17,8 +17,11 @@ document.addEventListener('DOMContentLoaded', () => {
     time.textContent = new Date(entry.date).toLocaleDateString('es-ES', { day: 'numeric', month: 'short', year: 'numeric' });
     article.appendChild(time);
     const p = document.createElement('p');
-    const snippet = entry.content.length > 120 ? entry.content.substring(0, 120) + '…' : entry.content;
-    p.innerHTML = snippet;
+    const html = marked.parse(entry.content);
+    const temp = document.createElement('div');
+    temp.innerHTML = html;
+    const firstP = temp.querySelector('p');
+    p.textContent = firstP ? firstP.textContent : '';
     article.appendChild(p);
     teaser.appendChild(article);
   });

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diario.js
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diario.js
@@ -5,6 +5,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function render(list) {
     container.innerHTML = '';
+    if (list.length === 0) {
+      const p = document.createElement('p');
+      p.textContent = 'No se encontraron entradas con esa búsqueda.';
+      container.appendChild(p);
+      return;
+    }
     let currentMonth = '';
     list.forEach(entry => {
       const date = new Date(entry.date);
@@ -28,9 +34,9 @@ document.addEventListener('DOMContentLoaded', () => {
       time.textContent = date.toLocaleDateString('es-ES', { day: 'numeric', month: 'long', year: 'numeric' });
       header.appendChild(time);
       article.appendChild(header);
-      const p = document.createElement('p');
-      p.innerHTML = entry.content;
-      article.appendChild(p);
+      const content = document.createElement('div');
+      content.innerHTML = marked.parse(entry.content);
+      article.appendChild(content);
       container.appendChild(article);
     });
   }


### PR DESCRIPTION
## Summary
- Parse diary entry content with Markdown and show message when searches are empty
- Show only the first paragraph as the diary teaser on the home page
- Apply dark theme styling to the diary section and load Markdown parser

## Testing
- `node tests/word-cycle.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c389b8090c8324860fe4c6002d7907