### PR TITLE
Ajustes de estilo en el diario

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -12556,13 +12556,15 @@ body {
   -webkit-box-orient: vertical;
 }
 
-.diary-page { background: #171717; color: #eaeaea; }
+.diary-page { background: #171717; color: #eaeaea; --bg-color:#171717; --text-color:#eaeaea; --nav-link-color:#ffa94d; }
 .diary-header { margin: 24px 0 8px; font-weight: 700; }
 .diary-month { margin: 40px 0 16px; font-weight: 600; font-size: 1.125rem; color:#cfcfcf;}
 .diary-grid { display:grid; grid-template-columns:1fr; gap:20px; }
 @media(min-width: 900px){ .diary-grid { grid-template-columns:1fr 1fr; } }
 .diary-card { background:#222; border-radius:14px; box-shadow:0 6px 18px rgba(0,0,0,.25); padding:20px; }
 .diary-card h3 { margin:0 0 6px; font-size:1.25rem; line-height:1.3; }
+.diary-card h3 a, .diary-featured h2 a { color:#ffa94d; text-decoration:none; }
+.diary-card h3 a:hover, .diary-featured h2 a:hover { color:#ffa94d; }
 .diary-date { color:#9aa0a6; font-size:.9rem; margin-bottom:8px; }
 .diary-excerpt { display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical; overflow:hidden; color:#d6d6d6; }
 .diary-featured { margin:32px 0; padding:28px; background:#1f1f1f; border-radius:16px; }

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/09/el-rico-es-rico-porque-es-rico/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/09/el-rico-es-rico-porque-es-rico/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="description" content="Notas breves y pensamientos de Rick Grisales" />
     <meta name="author" content="Rick Grisales" />
-    <title>Diary of a Lost Writer - Rick Grisales</title>
+    <title>Diario de un escritor perdido - Rick Grisales</title>
     <link rel="icon" type="image/x-icon" href="../../../../assets/orange.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="description" content="Notas breves y pensamientos de Rick Grisales" />
     <meta name="author" content="Rick Grisales" />
-    <title>Diary of a Lost Writer - Rick Grisales</title>
+    <title>Diario de un escritor perdido - Rick Grisales</title>
     <link rel="canonical" href="/diary/" />
     <link rel="icon" type="image/x-icon" href="../assets/orange.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -35,7 +35,7 @@
 
     <main class="container px-5">
         <header class="py-5 text-center">
-            <h1 class="display-5 fw-bolder diary-header"><span class="text-gradient d-inline">Diary of a Lost Writer</span></h1>
+            <h1 class="display-5 fw-bolder diary-header"><span class="text-gradient d-inline">Diario de un escritor perdido</span></h1>
             <p class="lead fw-normal text-muted mb-4">Pensamientos sueltos en busca de hogar.</p>
             <div class="mx-auto" style="max-width: 400px;">
                 <input type="search" id="diary-search" class="form-control" placeholder="Search..." aria-label="Buscar en el diario" />

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diary-post.js
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diary-post.js
@@ -38,6 +38,6 @@ document.addEventListener("DOMContentLoaded", async () => {
   const back = document.createElement("a");
   back.className = "back-link";
   back.href = "/diary/";
-  back.textContent = "← Back to Diary";
+  back.textContent = "← Volver al diario";
   container.appendChild(back);
 });


### PR DESCRIPTION
## Summary
- Cambia títulos del diario a español
- Unifica colores de cabecera y pie de página con el resto del sitio
- Resalta en naranja los títulos de las entradas

## Testing
- `node tests/word-cycle.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4278d08b883248d7877621d7eff5b