### PR TITLE
Fix diary button hover color and translate labels

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -12544,7 +12544,7 @@ html {
 .diary-excerpt { display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical; overflow:hidden; color:var(--muted-text-color); }
 .diary-featured { margin:32px 0; padding:28px; background:var(--section-bg-light); border-radius:16px; }
 .diary-cta { display:inline-block; margin-top:12px; padding:8px 14px; border:1px solid var(--color-border); border-radius:10px; text-decoration:none; color:var(--color-text); }
-.diary-cta:hover { border-color:var(--muted-text-color); }
+.diary-cta:hover { border-color:#FF6600; color:#FF6600; }
 blockquote { border-left:3px solid var(--color-border); padding-left:14px; color:var(--muted-text-color); font-style:italic; }
 h1.post-title { font-size:2.25rem; line-height:1.2; margin:10px 0 14px; }
 .post-date { color:var(--muted-text-color); font-size:.9rem; margin-bottom:16px; }

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diary-index.js
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diary-index.js
@@ -55,7 +55,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     const cta = document.createElement("a");
     cta.className = "diary-cta";
     cta.href = link.href;
-    cta.textContent = "Read full post";
+    cta.textContent = "Leer más";
     article.appendChild(cta);
 
     featuredEl.appendChild(article);
@@ -114,7 +114,7 @@ document.addEventListener("DOMContentLoaded", async () => {
           const cta = document.createElement("a");
           cta.className = "diary-cta";
           cta.href = link.href;
-          cta.textContent = "Read more";
+          cta.textContent = "Leer más";
           article.appendChild(cta);
 
           grid.appendChild(article);

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diary-teaser.js
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diary-teaser.js
@@ -35,7 +35,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     const cta = document.createElement("a");
     cta.className = "diary-cta";
     cta.href = link.href;
-    cta.textContent = "Read more";
+    cta.textContent = "Leer más";
     article.appendChild(cta);
 
     grid.appendChild(article);


### PR DESCRIPTION
## Summary
- Make diary call-to-action buttons turn orange on hover
- Replace English "Read" labels with "Leer más"

## Testing
- `node tests/word-cycle.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c59ea0af9883248f267a165d9509d2