### PR TITLE
Set diary buttons to orange on hover

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -12572,6 +12572,9 @@ body {
 .diary-featured { margin:32px 0; padding:28px; background:#1f1f1f; border-radius:16px; }
 .diary-cta { display:inline-block; margin-top:12px; padding:8px 14px; border:1px solid #888; border-radius:10px; text-decoration:none; color:#eaeaea; }
 .diary-cta:hover { border-color:#bbb; }
+@media (hover:hover) and (pointer:fine) {
+  .diary-cta:hover { color: var(--bs-orange); border-color: var(--bs-orange); }
+}
 blockquote { border-left:3px solid #4b5563; padding-left:14px; color:#c7c7c7; font-style:italic; }
 h1.post-title { font-size:2.25rem; line-height:1.2; margin:10px 0 14px; }
 .post-date { color:#9aa0a6; font-size:.9rem; margin-bottom:16px; }

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diary-index.js
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diary-index.js
@@ -55,7 +55,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     const cta = document.createElement("a");
     cta.className = "diary-cta";
     cta.href = link.href;
-    cta.textContent = "Read full post";
+    cta.textContent = "Leer más";
     article.appendChild(cta);
 
     featuredEl.appendChild(article);
@@ -114,7 +114,7 @@ document.addEventListener("DOMContentLoaded", async () => {
           const cta = document.createElement("a");
           cta.className = "diary-cta";
           cta.href = link.href;
-          cta.textContent = "Read more";
+          cta.textContent = "Leer más";
           article.appendChild(cta);
 
           grid.appendChild(article);

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diary-teaser.js
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diary-teaser.js
@@ -35,7 +35,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     const cta = document.createElement("a");
     cta.className = "diary-cta";
     cta.href = link.href;
-    cta.textContent = "Read more";
+    cta.textContent = "Leer más";
     article.appendChild(cta);
 
     grid.appendChild(article);


### PR DESCRIPTION
## Summary
- Translate diary call-to-action buttons to "Leer más"
- Highlight diary buttons in orange on hover for desktop users

## Testing
- `node tests/word-cycle.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c5a483764c83249cda8e600dc0781c