### PR TITLE
Add social share options to project and diary posts

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/arte-naturaleza.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/arte-naturaleza.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans&display=swap" rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" />
     <link href="css/styles.css" rel="stylesheet" />
     <style>
         /* Variables de color */
@@ -193,6 +194,43 @@
                 <li><strong>Precio:</strong> 6€ o gratis para clientes CaixaBank.</li>
                 <li><strong>Horarios:</strong> Todos los días, de 10 a 20 hrs.</li>
             </ul>
+
+            <div class="share-container" data-share-text="Del surrealismo a la crisis ecológica: Arte y naturaleza en diálogo">
+                <h2 class="share-title">Comparte este texto</h2>
+                <p class="share-description">Si te gustó, compártelo en tus redes sociales favoritas:</p>
+                <div class="share-buttons">
+                    <button type="button" class="share-button" data-share-network="facebook">
+                        <i class="bi bi-facebook"></i>
+                        <span>Facebook</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="x">
+                        <i class="bi bi-twitter-x"></i>
+                        <span>X</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="instagram">
+                        <i class="bi bi-instagram"></i>
+                        <span>Instagram</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="linkedin">
+                        <i class="bi bi-linkedin"></i>
+                        <span>LinkedIn</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="whatsapp">
+                        <i class="bi bi-whatsapp"></i>
+                        <span>WhatsApp</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="telegram">
+                        <i class="bi bi-telegram"></i>
+                        <span>Telegram</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="copy">
+                        <i class="bi bi-link-45deg"></i>
+                        <span>Copiar enlace</span>
+                    </button>
+                </div>
+                <p class="share-hint"><i class="bi bi-info-circle me-2"></i>Instagram no permite compartir enlaces automáticos, pero puedes pegar el enlace copiado en tus historias o mensajes.</p>
+                <p class="share-feedback" role="status" aria-live="polite"></p>
+            </div>
         </div>
     </section>
 </main>
@@ -213,5 +251,6 @@
 </footer>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="js/scripts.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -12589,3 +12589,89 @@ footer a.small,
 footer a.small:hover {
   color: var(--bs-orange);
 }
+
+/* Share component */
+.share-container {
+  margin-top: 3rem;
+  padding-top: 2.5rem;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="dark"] .share-container {
+  border-top-color: rgba(255, 255, 255, 0.12);
+}
+
+.share-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.share-description {
+  color: var(--muted-text-color);
+  margin-bottom: 1.5rem;
+}
+
+.share-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.share-button {
+  border: 1px solid var(--btn-outline-border);
+  background-color: transparent;
+  color: var(--text-color);
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  cursor: pointer;
+}
+
+.share-button .bi {
+  font-size: 1.1rem;
+}
+
+.share-button:hover,
+.share-button:focus-visible {
+  background-color: var(--text-color);
+  color: var(--bg-color);
+  border-color: var(--text-color);
+  outline: none;
+}
+
+.share-hint {
+  margin-top: 1.5rem;
+  font-size: 0.95rem;
+  color: var(--muted-text-color);
+}
+
+.share-feedback {
+  margin-top: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--nav-link-color);
+  display: none;
+}
+
+.share-feedback.is-visible {
+  display: block;
+}
+
+@media (max-width: 576px) {
+  .share-container {
+    padding-top: 2rem;
+  }
+
+  .share-buttons {
+    gap: 0.5rem;
+  }
+
+  .share-button {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/09/el-rico-es-rico-porque-es-rico/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/09/el-rico-es-rico-porque-es-rico/index.html
@@ -10,7 +10,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet" />
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" />
     <link href="../../../../css/styles.css" rel="stylesheet" />
 </head>
 <body class="diary-page">

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/index.html
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet" />
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" />
     <link href="../css/styles.css" rel="stylesheet" />
 </head>
 <body class="diary-page">

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diary-post.js
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diary-post.js
@@ -35,6 +35,50 @@ document.addEventListener("DOMContentLoaded", async () => {
   if (firstH1) firstH1.remove();
   container.appendChild(content);
 
+  const share = document.createElement("div");
+  share.className = "share-container";
+  share.setAttribute("data-share-text", entry.title);
+  share.innerHTML = `
+    <h2 class="share-title">Comparte este texto</h2>
+    <p class="share-description">Si te gustó, compártelo en tus redes sociales favoritas:</p>
+    <div class="share-buttons">
+      <button type="button" class="share-button" data-share-network="facebook">
+        <i class="bi bi-facebook"></i>
+        <span>Facebook</span>
+      </button>
+      <button type="button" class="share-button" data-share-network="x">
+        <i class="bi bi-twitter-x"></i>
+        <span>X</span>
+      </button>
+      <button type="button" class="share-button" data-share-network="instagram">
+        <i class="bi bi-instagram"></i>
+        <span>Instagram</span>
+      </button>
+      <button type="button" class="share-button" data-share-network="linkedin">
+        <i class="bi bi-linkedin"></i>
+        <span>LinkedIn</span>
+      </button>
+      <button type="button" class="share-button" data-share-network="whatsapp">
+        <i class="bi bi-whatsapp"></i>
+        <span>WhatsApp</span>
+      </button>
+      <button type="button" class="share-button" data-share-network="telegram">
+        <i class="bi bi-telegram"></i>
+        <span>Telegram</span>
+      </button>
+      <button type="button" class="share-button" data-share-network="copy">
+        <i class="bi bi-link-45deg"></i>
+        <span>Copiar enlace</span>
+      </button>
+    </div>
+    <p class="share-hint"><i class="bi bi-info-circle me-2"></i>Instagram no permite compartir enlaces automáticos, pero puedes pegar el enlace copiado en tus historias o mensajes.</p>
+    <p class="share-feedback" role="status" aria-live="polite"></p>
+  `;
+  container.appendChild(share);
+  if (typeof window.initializeShareButtons === "function") {
+    window.initializeShareButtons(share);
+  }
+
   const back = document.createElement("a");
   back.className = "back-link";
   back.href = "/diary/";

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/scripts.js
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/scripts.js
@@ -1,7 +1,172 @@
 /*!
-* Start Bootstrap - Personal v1.0.1 (https://startbootstrap.com/template-overviews/personal)
-* Copyright 2013-2023 Start Bootstrap
-* Licensed under MIT (https://github.com/StartBootstrap/startbootstrap-personal/blob/master/LICENSE)
-*/
-// This file is intentionally blank
-// Use this file to add JavaScript to your project
+ * Start Bootstrap - Personal v1.0.1 (https://startbootstrap.com/template-overviews/personal)
+ * Copyright 2013-2023 Start Bootstrap
+ * Licensed under MIT (https://github.com/StartBootstrap/startbootstrap-personal/blob/master/LICENSE)
+ */
+// This file adds custom interactions for the site.
+
+(function () {
+  const INSTAGRAM_URL = "https://www.instagram.com/";
+
+  function buildShareUrl(network, url, text) {
+    const encodedUrl = encodeURIComponent(url);
+    const encodedText = encodeURIComponent(text);
+
+    switch (network) {
+      case "facebook":
+        return `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`;
+      case "x":
+        return `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedText}`;
+      case "linkedin":
+        return `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`;
+      case "whatsapp":
+        return `https://api.whatsapp.com/send?text=${encodedText}%20${encodedUrl}`;
+      case "telegram":
+        return `https://t.me/share/url?url=${encodedUrl}&text=${encodedText}`;
+      default:
+        return "";
+    }
+  }
+
+  function openShareWindow(url) {
+    window.open(url, "_blank", "noopener,noreferrer,width=600,height=600");
+  }
+
+  function getFeedbackElement(container) {
+    return (
+      container.querySelector(".share-feedback") ||
+      container.querySelector("[data-share-feedback]")
+    );
+  }
+
+  function showFeedback(container, message) {
+    const feedback = getFeedbackElement(container);
+    if (!feedback) return;
+
+    feedback.textContent = message;
+    feedback.classList.add("is-visible");
+    window.setTimeout(() => {
+      feedback.classList.remove("is-visible");
+    }, 4000);
+  }
+
+  async function copyToClipboard(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        return true;
+      } catch (error) {
+        console.warn("Clipboard API error", error);
+      }
+    }
+
+    try {
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.setAttribute("readonly", "");
+      textarea.style.position = "absolute";
+      textarea.style.left = "-9999px";
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      return true;
+    } catch (error) {
+      console.warn("Fallback clipboard copy failed", error);
+    }
+
+    return false;
+  }
+
+  function prepareShareButtons(root = document) {
+    const shareBlocks = root.querySelectorAll(".share-container");
+
+    shareBlocks.forEach((block) => {
+      if (block.dataset.shareInitialised === "true") {
+        return;
+      }
+
+      const baseUrl =
+        block.getAttribute("data-share-url") || window.location.href;
+      const baseText =
+        block.getAttribute("data-share-text") || document.title || baseUrl;
+
+      const buttons = block.querySelectorAll("[data-share-network]");
+
+      buttons.forEach((button) => {
+        const network = button.getAttribute("data-share-network");
+        if (!network) return;
+
+        if (network === "copy") {
+          button.addEventListener("click", async (event) => {
+            event.preventDefault();
+            const copied = await copyToClipboard(baseUrl);
+            if (copied) {
+              showFeedback(
+                block,
+                "Enlace copiado. ¡Compártelo donde quieras!",
+              );
+            } else {
+              showFeedback(
+                block,
+                "No se pudo copiar automáticamente. Copia el enlace manualmente.",
+              );
+            }
+          });
+          return;
+        }
+
+        if (network === "instagram") {
+          button.addEventListener("click", async (event) => {
+            event.preventDefault();
+            const copied = await copyToClipboard(baseUrl);
+            if (copied) {
+              showFeedback(
+                block,
+                "Enlace copiado. Abre Instagram y pégalo en tu historia o bio.",
+              );
+            }
+            window.open(INSTAGRAM_URL, "_blank", "noopener");
+          });
+          return;
+        }
+
+        if (network === "native" && navigator.share) {
+          button.addEventListener("click", (event) => {
+            event.preventDefault();
+            navigator
+              .share({
+                title: baseText,
+                text: baseText,
+                url: baseUrl,
+              })
+              .catch((error) => {
+                if (error && error.name !== "AbortError") {
+                  console.warn("Native share failed", error);
+                }
+              });
+          });
+          return;
+        }
+
+        const shareUrl = buildShareUrl(network, baseUrl, baseText);
+        if (!shareUrl) {
+          return;
+        }
+
+        button.addEventListener("click", (event) => {
+          event.preventDefault();
+          openShareWindow(shareUrl);
+        });
+      });
+
+      block.dataset.shareInitialised = "true";
+    });
+  }
+
+  window.initializeShareButtons = prepareShareButtons;
+
+  document.addEventListener("DOMContentLoaded", () => {
+    prepareShareButtons(document);
+  });
+})();

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/kali-uchis.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/kali-uchis.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans&family=Playfair+Display:wght@400;600&display=swap" rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" />
     <link href="css/styles.css" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet" />
     <style>
@@ -213,6 +214,43 @@
                     <li><strong>Géneros:</strong> R&amp;B alternativo, dream pop, soul, psicodelia latina</li>
                 </ul>
             </div>
+
+            <div class="share-container" data-share-text="Amor, duelo y libertad: el álbum más íntimo de Kali Uchis">
+                <h2 class="share-title">Comparte este texto</h2>
+                <p class="share-description">Si te gustó, compártelo en tus redes sociales favoritas:</p>
+                <div class="share-buttons">
+                    <button type="button" class="share-button" data-share-network="facebook">
+                        <i class="bi bi-facebook"></i>
+                        <span>Facebook</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="x">
+                        <i class="bi bi-twitter-x"></i>
+                        <span>X</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="instagram">
+                        <i class="bi bi-instagram"></i>
+                        <span>Instagram</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="linkedin">
+                        <i class="bi bi-linkedin"></i>
+                        <span>LinkedIn</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="whatsapp">
+                        <i class="bi bi-whatsapp"></i>
+                        <span>WhatsApp</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="telegram">
+                        <i class="bi bi-telegram"></i>
+                        <span>Telegram</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="copy">
+                        <i class="bi bi-link-45deg"></i>
+                        <span>Copiar enlace</span>
+                    </button>
+                </div>
+                <p class="share-hint"><i class="bi bi-info-circle me-2"></i>Instagram no permite compartir enlaces automáticos, pero puedes pegar el enlace copiado en tus historias o mensajes.</p>
+                <p class="share-feedback" role="status" aria-live="polite"></p>
+            </div>
         </div>
     </section>
 </main>
@@ -231,5 +269,6 @@
     </div>
 </footer>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="js/scripts.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/poder-mentira.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/poder-mentira.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans&display=swap" rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" />
     <link href="css/styles.css" rel="stylesheet" />
     <style>
         /* Variables de color */
@@ -222,6 +223,43 @@
             
             <p>Sin una solución o una respuesta que se asome in el horizonte, quizá el amor pueda ser una guía. Al igual que las emociones que nos manipulan, también apela a lo profundo de nuestra humanidad. Sin embargo, a diferencia del miedo o la indignación, el amor tiene el potencial de construir in lugar de destruir, de unir in lugar de fragmentar. Si bien el romanticismo puede ser emocionalidad, no es irracionalidad; es una elección consciente que puede guiar nuestros valores hacia el entendimiento y la empatía colectiva. In esta dicotomía de emociones, el amor puede ser el antídoto: no porque sea sencillo o idealizado, sino porque fomenta la empatía, la reflexión y, sobre todo, el compromiso con la verdad y con los otros. Carl Jung decía: “Donde el amor reina, no hay voluntad de poder; y donde el poder predomina, el amor falta”. Al final, lo que está in juego no es solo la verdad, sino nuestra capacidad de imaginar una democracia que sea resiliente in su imperfección. Y quizá ahí resida la clave: in reconocer que, aunque no podamos controlar todo, todavía podemos decidir cómo enfrentarlo.</p>
             <p class="highlight-quote">El amor puede ser el antídoto: no porque sea sencillo o idealizado, sino porque fomenta la empatía, la reflexión y, sobre todo, el compromiso con la verdad y con los otros.</p>
+
+            <div class="share-container" data-share-text="La política del engaño">
+                <h2 class="share-title">Comparte este texto</h2>
+                <p class="share-description">Si te gustó, compártelo en tus redes sociales favoritas:</p>
+                <div class="share-buttons">
+                    <button type="button" class="share-button" data-share-network="facebook">
+                        <i class="bi bi-facebook"></i>
+                        <span>Facebook</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="x">
+                        <i class="bi bi-twitter-x"></i>
+                        <span>X</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="instagram">
+                        <i class="bi bi-instagram"></i>
+                        <span>Instagram</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="linkedin">
+                        <i class="bi bi-linkedin"></i>
+                        <span>LinkedIn</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="whatsapp">
+                        <i class="bi bi-whatsapp"></i>
+                        <span>WhatsApp</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="telegram">
+                        <i class="bi bi-telegram"></i>
+                        <span>Telegram</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="copy">
+                        <i class="bi bi-link-45deg"></i>
+                        <span>Copiar enlace</span>
+                    </button>
+                </div>
+                <p class="share-hint"><i class="bi bi-info-circle me-2"></i>Instagram no permite compartir enlaces automáticos, pero puedes pegar el enlace copiado en tus historias o mensajes.</p>
+                <p class="share-feedback" role="status" aria-live="polite"></p>
+            </div>
         </div>
     </section>
 </main>
@@ -242,5 +280,6 @@
 </footer>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="js/scripts.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/salomon.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/salomon.html
@@ -13,6 +13,7 @@
     
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" />
     
     <!-- Tu CSS base -->
     <link href="css/styles.css" rel="stylesheet" />
@@ -243,6 +244,43 @@
             <p class="highlight-quote">El bebé muerto en la obra no es un detalle más que adorna la pintura, es un elemento lleno de significado.</p>
             
             <p>En definitiva, la pintura es una escena llena de fuerza, emocionalidad, belleza y significado. Es también un cuadro más en los pasillos del maravilloso Thyssen, pero absolutamente una experiencia histórica que se debe vivir. El juicio de Salomón ha fascinado a las personas durante siglos. Tiene conexiones profundas con la sabiduría, la justicia y la compasión, y su mensaje sigue siendo relevante hoy en día. Giordano representa vívidamente la historia y nos recuerda que, en manos de poder legítimo, la justicia siempre triunfa sobre la injusticia.</p>
+
+            <div class="share-container" data-share-text="La abnegación más pura: la maternidad">
+                <h2 class="share-title">Comparte este texto</h2>
+                <p class="share-description">Si te gustó, compártelo en tus redes sociales favoritas:</p>
+                <div class="share-buttons">
+                    <button type="button" class="share-button" data-share-network="facebook">
+                        <i class="bi bi-facebook"></i>
+                        <span>Facebook</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="x">
+                        <i class="bi bi-twitter-x"></i>
+                        <span>X</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="instagram">
+                        <i class="bi bi-instagram"></i>
+                        <span>Instagram</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="linkedin">
+                        <i class="bi bi-linkedin"></i>
+                        <span>LinkedIn</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="whatsapp">
+                        <i class="bi bi-whatsapp"></i>
+                        <span>WhatsApp</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="telegram">
+                        <i class="bi bi-telegram"></i>
+                        <span>Telegram</span>
+                    </button>
+                    <button type="button" class="share-button" data-share-network="copy">
+                        <i class="bi bi-link-45deg"></i>
+                        <span>Copiar enlace</span>
+                    </button>
+                </div>
+                <p class="share-hint"><i class="bi bi-info-circle me-2"></i>Instagram no permite compartir enlaces automáticos, pero puedes pegar el enlace copiado en tus historias o mensajes.</p>
+                <p class="share-feedback" role="status" aria-live="polite"></p>
+            </div>
         </div>
     </section>
 </main>
@@ -267,6 +305,8 @@
 
 <!-- Bootstrap core JS -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+
+<script src="js/scripts.js"></script>
 
 
 


### PR DESCRIPTION
## Summary
- style share components that adapt to the current theme and mobile screens
- add JavaScript helpers to open share dialogs, copy links, and handle Instagram sharing gracefully
- surface the share controls in every project article and generated diary entry, updating icon assets where needed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8c3a1c0748324adae165bc2847493