### PR TITLE
Fix mobile share button styling

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -12627,8 +12627,11 @@ footer a.small:hover {
 }
 
 .share-button {
+  -webkit-appearance: none;
+  appearance: none;
   border: 1px solid var(--share-button-bg);
   background-color: var(--share-button-bg);
+  background-image: none;
   color: var(--share-button-text);
   padding: 0.5rem 0.9rem;
   border-radius: 999px;
@@ -12640,10 +12643,21 @@ footer a.small:hover {
     box-shadow 0.2s ease;
   cursor: pointer;
   box-shadow: none;
+  text-decoration: none;
 }
 
 .share-button .bi {
   font-size: 1.1rem;
+}
+
+.share-button span {
+  color: inherit;
+  text-decoration: none;
+}
+
+.share-button:hover span,
+.share-button:focus-visible span {
+  text-decoration: none;
 }
 
 .share-button:hover,
@@ -12652,6 +12666,7 @@ footer a.small:hover {
   color: var(--share-button-text);
   border-color: var(--share-button-bg-hover);
   outline: none;
+  text-decoration: none;
 }
 
 .share-button:focus-visible {


### PR DESCRIPTION
## Summary
- remove the native browser styling from the share buttons so the custom orange palette is applied consistently on mobile
- ensure the share button labels keep the decoration removed on hover and focus

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68c8cd2a94cc832499c2ced314e16b42