### PR TITLE
Remove share buttons and align diary navigation styles

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/arte-naturaleza.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/arte-naturaleza.html
@@ -195,42 +195,6 @@
                 <li><strong>Horarios:</strong> Todos los días, de 10 a 20 hrs.</li>
             </ul>
 
-            <div class="share-container" data-share-text="Del surrealismo a la crisis ecológica: Arte y naturaleza en diálogo">
-                <h2 class="share-title">Comparte este texto</h2>
-                <p class="share-description">Si te gustó, compártelo en tus redes sociales favoritas:</p>
-                <div class="share-buttons">
-                    <button type="button" class="share-button" data-share-network="facebook">
-                        <i class="bi bi-facebook"></i>
-                        <span>Facebook</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="x">
-                        <i class="bi bi-twitter-x"></i>
-                        <span>X</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="instagram">
-                        <i class="bi bi-instagram"></i>
-                        <span>Instagram</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="linkedin">
-                        <i class="bi bi-linkedin"></i>
-                        <span>LinkedIn</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="whatsapp">
-                        <i class="bi bi-whatsapp"></i>
-                        <span>WhatsApp</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="telegram">
-                        <i class="bi bi-telegram"></i>
-                        <span>Telegram</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="copy">
-                        <i class="bi bi-link-45deg"></i>
-                        <span>Copiar enlace</span>
-                    </button>
-                </div>
-                <p class="share-hint"><i class="bi bi-info-circle me-2"></i>Instagram no permite compartir enlaces automáticos, pero puedes pegar el enlace copiado en tus historias o mensajes.</p>
-                <p class="share-feedback" role="status" aria-live="polite"></p>
-            </div>
         </div>
     </section>
 </main>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -84,6 +84,7 @@
   --section-bg-light: #f8f9fa;   /* Fondo de secciones claras en modo claro */
   --btn-outline-border: #000000; /* Borde del botón outline en modo claro */
   --caption-color: #555;         /* Color de los pies de página en modo claro */
+  --hamburger-color: #ffa94d;    /* Color del icono y borde del menú hamburguesa */
 }
 
 [data-theme="dark"] {
@@ -94,6 +95,7 @@
   --section-bg-light: #1e1e1e;   /* Fondo de secciones claras en modo oscuro */
   --btn-outline-border: #ffffff; /* Borde del botón outline en modo oscuro */
   --caption-color: #bbb;         /* Color de los pies de página en modo oscuro */
+  --hamburger-color: #ffa94d;    /* Color del icono y borde del menú hamburguesa en modo oscuro */
   --bs-link-color: #ffa94d;      /* Color de los enlaces en modo oscuro */
   --bs-link-hover-color: #ffa94d;/* Color de los enlaces al pasar el cursor */
 }
@@ -11898,11 +11900,28 @@ html {
 }
 
 .navbar-toggler {
-  border-color: var(--text-color);
+  border-color: var(--hamburger-color);
+  --bs-navbar-toggler-border-color: var(--hamburger-color);
+}
+
+.navbar-toggler:focus,
+.navbar-toggler:focus-visible {
+  box-shadow: 0 0 0 0.25rem rgba(255, 138, 0, 0.35);
 }
 
 .navbar-toggler-icon {
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(255, 169, 77, 1)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+  color: var(--hamburger-color);
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='currentColor' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}
+
+.navbar-dark .navbar-toggler,
+.navbar-light .navbar-toggler {
+  border-color: var(--hamburger-color);
+}
+
+.navbar-dark .navbar-toggler-icon,
+.navbar-light .navbar-toggler-icon {
+  color: var(--hamburger-color);
 }
 
 .cursor-blink {
@@ -12587,8 +12606,6 @@ blockquote { border-left:3px solid #4b5563; padding-left:14px; color:#c7c7c7; fo
 h1.post-title { font-size:2.25rem; line-height:1.2; margin:10px 0 14px; }
 .post-date { color:#9aa0a6; font-size:.9rem; margin-bottom:16px; }
 .post-content p { margin:0 0 16px; line-height:1.75; }
-.back-link { display:inline-block; margin-top:28px; color:#eaeaea; text-decoration:none; border-bottom:1px solid #666; }
-.back-link:hover{ border-bottom-color:#aaa; }
 .diary-teaser { grid-template-columns:1fr; }
 @media(min-width:600px){ .diary-teaser { grid-template-columns:1fr 1fr; } }
 @media(min-width:900px){ .diary-teaser { grid-template-columns:repeat(4,1fr); } }

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diary-post.js
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diary-post.js
@@ -14,6 +14,20 @@ document.addEventListener("DOMContentLoaded", async () => {
     return;
   }
 
+  const back = document.createElement("a");
+  back.className = "btn btn-warning position-fixed top-0 start-0 m-3";
+  back.href = "/diary/";
+  back.textContent = "← Volver";
+  back.addEventListener("click", (event) => {
+    event.preventDefault();
+    if (window.history.length > 1) {
+      window.history.back();
+    } else {
+      window.location.href = back.href;
+    }
+  });
+  container.appendChild(back);
+
   const h1 = document.createElement("h1");
   h1.className = "post-title";
   h1.textContent = entry.title;
@@ -34,54 +48,4 @@ document.addEventListener("DOMContentLoaded", async () => {
   const firstH1 = content.querySelector("h1");
   if (firstH1) firstH1.remove();
   container.appendChild(content);
-
-  const share = document.createElement("div");
-  share.className = "share-container";
-  share.setAttribute("data-share-text", entry.title);
-  share.innerHTML = `
-    <h2 class="share-title">Comparte este texto</h2>
-    <p class="share-description">Si te gustó, compártelo en tus redes sociales favoritas:</p>
-    <div class="share-buttons">
-      <button type="button" class="share-button" data-share-network="facebook">
-        <i class="bi bi-facebook"></i>
-        <span>Facebook</span>
-      </button>
-      <button type="button" class="share-button" data-share-network="x">
-        <i class="bi bi-twitter-x"></i>
-        <span>X</span>
-      </button>
-      <button type="button" class="share-button" data-share-network="instagram">
-        <i class="bi bi-instagram"></i>
-        <span>Instagram</span>
-      </button>
-      <button type="button" class="share-button" data-share-network="linkedin">
-        <i class="bi bi-linkedin"></i>
-        <span>LinkedIn</span>
-      </button>
-      <button type="button" class="share-button" data-share-network="whatsapp">
-        <i class="bi bi-whatsapp"></i>
-        <span>WhatsApp</span>
-      </button>
-      <button type="button" class="share-button" data-share-network="telegram">
-        <i class="bi bi-telegram"></i>
-        <span>Telegram</span>
-      </button>
-      <button type="button" class="share-button" data-share-network="copy">
-        <i class="bi bi-link-45deg"></i>
-        <span>Copiar enlace</span>
-      </button>
-    </div>
-    <p class="share-hint"><i class="bi bi-info-circle me-2"></i>Instagram no permite compartir enlaces automáticos, pero puedes pegar el enlace copiado en tus historias o mensajes.</p>
-    <p class="share-feedback" role="status" aria-live="polite"></p>
-  `;
-  container.appendChild(share);
-  if (typeof window.initializeShareButtons === "function") {
-    window.initializeShareButtons(share);
-  }
-
-  const back = document.createElement("a");
-  back.className = "back-link";
-  back.href = "/diary/";
-  back.textContent = "← Volver al diario";
-  container.appendChild(back);
 });

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/kali-uchis.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/kali-uchis.html
@@ -215,42 +215,6 @@
                 </ul>
             </div>
 
-            <div class="share-container" data-share-text="Amor, duelo y libertad: el álbum más íntimo de Kali Uchis">
-                <h2 class="share-title">Comparte este texto</h2>
-                <p class="share-description">Si te gustó, compártelo en tus redes sociales favoritas:</p>
-                <div class="share-buttons">
-                    <button type="button" class="share-button" data-share-network="facebook">
-                        <i class="bi bi-facebook"></i>
-                        <span>Facebook</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="x">
-                        <i class="bi bi-twitter-x"></i>
-                        <span>X</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="instagram">
-                        <i class="bi bi-instagram"></i>
-                        <span>Instagram</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="linkedin">
-                        <i class="bi bi-linkedin"></i>
-                        <span>LinkedIn</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="whatsapp">
-                        <i class="bi bi-whatsapp"></i>
-                        <span>WhatsApp</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="telegram">
-                        <i class="bi bi-telegram"></i>
-                        <span>Telegram</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="copy">
-                        <i class="bi bi-link-45deg"></i>
-                        <span>Copiar enlace</span>
-                    </button>
-                </div>
-                <p class="share-hint"><i class="bi bi-info-circle me-2"></i>Instagram no permite compartir enlaces automáticos, pero puedes pegar el enlace copiado en tus historias o mensajes.</p>
-                <p class="share-feedback" role="status" aria-live="polite"></p>
-            </div>
         </div>
     </section>
 </main>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/poder-mentira.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/poder-mentira.html
@@ -224,42 +224,6 @@
             <p>Sin una solución o una respuesta que se asome in el horizonte, quizá el amor pueda ser una guía. Al igual que las emociones que nos manipulan, también apela a lo profundo de nuestra humanidad. Sin embargo, a diferencia del miedo o la indignación, el amor tiene el potencial de construir in lugar de destruir, de unir in lugar de fragmentar. Si bien el romanticismo puede ser emocionalidad, no es irracionalidad; es una elección consciente que puede guiar nuestros valores hacia el entendimiento y la empatía colectiva. In esta dicotomía de emociones, el amor puede ser el antídoto: no porque sea sencillo o idealizado, sino porque fomenta la empatía, la reflexión y, sobre todo, el compromiso con la verdad y con los otros. Carl Jung decía: “Donde el amor reina, no hay voluntad de poder; y donde el poder predomina, el amor falta”. Al final, lo que está in juego no es solo la verdad, sino nuestra capacidad de imaginar una democracia que sea resiliente in su imperfección. Y quizá ahí resida la clave: in reconocer que, aunque no podamos controlar todo, todavía podemos decidir cómo enfrentarlo.</p>
             <p class="highlight-quote">El amor puede ser el antídoto: no porque sea sencillo o idealizado, sino porque fomenta la empatía, la reflexión y, sobre todo, el compromiso con la verdad y con los otros.</p>
 
-            <div class="share-container" data-share-text="La política del engaño">
-                <h2 class="share-title">Comparte este texto</h2>
-                <p class="share-description">Si te gustó, compártelo en tus redes sociales favoritas:</p>
-                <div class="share-buttons">
-                    <button type="button" class="share-button" data-share-network="facebook">
-                        <i class="bi bi-facebook"></i>
-                        <span>Facebook</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="x">
-                        <i class="bi bi-twitter-x"></i>
-                        <span>X</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="instagram">
-                        <i class="bi bi-instagram"></i>
-                        <span>Instagram</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="linkedin">
-                        <i class="bi bi-linkedin"></i>
-                        <span>LinkedIn</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="whatsapp">
-                        <i class="bi bi-whatsapp"></i>
-                        <span>WhatsApp</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="telegram">
-                        <i class="bi bi-telegram"></i>
-                        <span>Telegram</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="copy">
-                        <i class="bi bi-link-45deg"></i>
-                        <span>Copiar enlace</span>
-                    </button>
-                </div>
-                <p class="share-hint"><i class="bi bi-info-circle me-2"></i>Instagram no permite compartir enlaces automáticos, pero puedes pegar el enlace copiado en tus historias o mensajes.</p>
-                <p class="share-feedback" role="status" aria-live="polite"></p>
-            </div>
         </div>
     </section>
 </main>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/salomon.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/salomon.html
@@ -245,42 +245,6 @@
             
             <p>En definitiva, la pintura es una escena llena de fuerza, emocionalidad, belleza y significado. Es también un cuadro más en los pasillos del maravilloso Thyssen, pero absolutamente una experiencia histórica que se debe vivir. El juicio de Salomón ha fascinado a las personas durante siglos. Tiene conexiones profundas con la sabiduría, la justicia y la compasión, y su mensaje sigue siendo relevante hoy en día. Giordano representa vívidamente la historia y nos recuerda que, en manos de poder legítimo, la justicia siempre triunfa sobre la injusticia.</p>
 
-            <div class="share-container" data-share-text="La abnegación más pura: la maternidad">
-                <h2 class="share-title">Comparte este texto</h2>
-                <p class="share-description">Si te gustó, compártelo en tus redes sociales favoritas:</p>
-                <div class="share-buttons">
-                    <button type="button" class="share-button" data-share-network="facebook">
-                        <i class="bi bi-facebook"></i>
-                        <span>Facebook</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="x">
-                        <i class="bi bi-twitter-x"></i>
-                        <span>X</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="instagram">
-                        <i class="bi bi-instagram"></i>
-                        <span>Instagram</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="linkedin">
-                        <i class="bi bi-linkedin"></i>
-                        <span>LinkedIn</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="whatsapp">
-                        <i class="bi bi-whatsapp"></i>
-                        <span>WhatsApp</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="telegram">
-                        <i class="bi bi-telegram"></i>
-                        <span>Telegram</span>
-                    </button>
-                    <button type="button" class="share-button" data-share-network="copy">
-                        <i class="bi bi-link-45deg"></i>
-                        <span>Copiar enlace</span>
-                    </button>
-                </div>
-                <p class="share-hint"><i class="bi bi-info-circle me-2"></i>Instagram no permite compartir enlaces automáticos, pero puedes pegar el enlace copiado en tus historias o mensajes.</p>
-                <p class="share-feedback" role="status" aria-live="polite"></p>
-            </div>
         </div>
     </section>
 </main>


### PR DESCRIPTION
## Summary
- remove the social sharing widgets from the article pages and diary entries
- update the hamburger toggler styling so it stays orange on every page
- add the floating orange “Volver” button to diary entries with history navigation fallback

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8cf0895e0832482e8a0c36c5b2e0f