### PR TITLE
Reduce profile container and image max sizes in styles.css

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -11634,12 +11634,12 @@ html {
   width: 75vw;
   border-radius: 5vw;
   margin-top: 5vw;
-  max-height: 40rem;
-  max-width: 40rem;
+  max-height: 28rem;
+  max-width: 28rem;
 }
 .profile .profile-img {
   height: 80vw;
-  max-height: 45rem;
+  max-height: 31rem;
   position: absolute;
   bottom: 0;
   left: 50%;


### PR DESCRIPTION
### Motivation
- Reduce the maximum size of the profile container and profile image to improve layout fit and responsiveness.

### Description
- Updated `startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css` by changing the `.profile` rule `max-height` and `max-width` from `40rem` to `28rem`, and changing `.profile .profile-img` `max-height` from `45rem` to `31rem`.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e83638aecc832494f5ac416ed4bb38)