### PR TITLE
Adjust profile max dimensions in styles.css

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -11634,12 +11634,12 @@ html {
   width: 75vw;
   border-radius: 5vw;
   margin-top: 5vw;
-  max-height: 28rem;
-  max-width: 28rem;
+  max-height: 20rem;
+  max-width: 20rem;
 }
 .profile .profile-img {
   height: 80vw;
-  max-height: 31rem;
+  max-height: 22rem;
   position: absolute;
   bottom: 0;
   left: 50%;


### PR DESCRIPTION
### Motivation
- Reduce the displayed size limits for the profile container and profile image to match updated design constraints by changing the CSS max-dimensions.

### Description
- Change `max-height` and `max-width` of the `* .profile` rule to `20rem` and change `max-height` of the `* .profile .profile-img` rule to `22rem` in `startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css`.

### Testing
- Verified the edit with `git diff -- startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css`, inspected the updated lines with `nl -ba startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css`, and committed the change successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e83f04932483249ccb6799c7f6fbab)