### PR TITLE
Set light theme default and add shared theme toggle across all pages

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/arte-naturaleza.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/arte-naturaleza.html
@@ -126,6 +126,9 @@
     </style>
 </head>
 <body class="d-flex flex-column h-100">
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+  <i class="bi bi-moon-fill"></i>
+</button>
 <main class="flex-shrink-0">
     <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
         <div class="container px-5">
@@ -216,5 +219,6 @@
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="js/scripts.js"></script>
+    <script src="js/theme-toggle.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/contact.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/contact.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="light">
+<html lang="es" data-theme="light">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
@@ -121,6 +121,9 @@
     </style>
 </head>
 <body class="d-flex flex-column">
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+  <i class="bi bi-moon-fill"></i>
+</button>
     <main class="flex-shrink-0">
         <!-- Navigation-->
         <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
@@ -211,5 +214,6 @@
     <script src="js/scripts.js"></script>
     <!-- SB Forms JS -->
     <script src="https://cdn.startbootstrap.com/sb-forms-latest.js"></script>
+    <script src="js/theme-toggle.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -12721,3 +12721,38 @@ footer a.small:hover {
     justify-content: center;
   }
 }
+
+/* === Theme Toggle Button === */
+.theme-toggle-btn {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 1000;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  color: #212529;
+  transition: all 0.3s ease;
+}
+
+.theme-toggle-btn i {
+  pointer-events: none;
+}
+
+[data-theme="dark"] .theme-toggle-btn {
+  color: #f8f9fa;
+}
+
+@media (max-width: 768px) {
+  .theme-toggle-btn {
+    top: 4.5rem;
+    right: 0.75rem;
+  }
+}

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/09/el-rico-es-rico-porque-es-rico/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/09/el-rico-es-rico-porque-es-rico/index.html
@@ -14,6 +14,9 @@
     <link href="../../../../css/styles.css" rel="stylesheet" />
 </head>
 <body class="diary-page">
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+  <i class="bi bi-moon-fill"></i>
+</button>
     <nav class="navbar navbar-expand-lg navbar-dark py-3">
         <div class="container px-5">
             <a class="navbar-brand" href="../../../../index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
@@ -53,9 +56,9 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="../../../../js/scripts.js"></script>
-    <script src="../../../../js/dark-mode.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="../../../../js/diary-utils.js"></script>
     <script src="../../../../js/diary-post.js"></script>
+    <script src="../../../../js/theme-toggle.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/10/aun-estoy-a-tiempo/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/10/aun-estoy-a-tiempo/index.html
@@ -14,6 +14,9 @@
     <link href="../../../../css/styles.css" rel="stylesheet" />
 </head>
 <body class="diary-page">
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+  <i class="bi bi-moon-fill"></i>
+</button>
     <nav class="navbar navbar-expand-lg navbar-dark py-3">
         <div class="container px-5">
             <a class="navbar-brand" href="../../../../index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
@@ -53,9 +56,9 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="../../../../js/scripts.js"></script>
-    <script src="../../../../js/dark-mode.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="../../../../js/diary-utils.js"></script>
     <script src="../../../../js/diary-post.js"></script>
+    <script src="../../../../js/theme-toggle.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/10/fotosintesis/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/10/fotosintesis/index.html
@@ -14,6 +14,9 @@
     <link href="../../../../css/styles.css" rel="stylesheet" />
 </head>
 <body class="diary-page">
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+  <i class="bi bi-moon-fill"></i>
+</button>
     <nav class="navbar navbar-expand-lg navbar-dark py-3">
         <div class="container px-5">
             <a class="navbar-brand" href="../../../../index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
@@ -53,9 +56,9 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="../../../../js/scripts.js"></script>
-    <script src="../../../../js/dark-mode.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="../../../../js/diary-utils.js"></script>
     <script src="../../../../js/diary-post.js"></script>
+    <script src="../../../../js/theme-toggle.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/index.html
@@ -15,6 +15,9 @@
     <link href="../css/styles.css" rel="stylesheet" />
 </head>
 <body class="diary-page">
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+  <i class="bi bi-moon-fill"></i>
+</button>
     <nav class="navbar navbar-expand-lg navbar-dark py-3">
         <div class="container px-5">
             <a class="navbar-brand" href="../index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
@@ -68,9 +71,9 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="../js/scripts.js"></script>
-    <script src="../js/dark-mode.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="../js/diary-utils.js"></script>
     <script src="../js/diary-index.js"></script>
+    <script src="../js/theme-toggle.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/gracias.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/gracias.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="light">
+<html lang="es" data-theme="light">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
@@ -116,6 +116,9 @@
     </style>
 </head>
 <body class="d-flex flex-column h-100">
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+  <i class="bi bi-moon-fill"></i>
+</button>
     <main class="flex-shrink-0">
         <!-- Navigation -->
         <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
@@ -175,5 +178,6 @@
     <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="js/scripts.js"></script>
+    <script src="js/theme-toggle.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="light">
+<html lang="es" data-theme="light">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
@@ -259,6 +259,9 @@
     </style>
 </head>
 <body class="d-flex flex-column h-100">
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+  <i class="bi bi-moon-fill"></i>
+</button>
     <main class="flex-shrink-0">
         <!-- Navigation-->
         <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
@@ -445,5 +448,6 @@
     <script src="js/diary-teaser.js"></script>
     <script src="js/word-cycle.js"></script>
 
+    <script src="js/theme-toggle.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/theme-toggle.js
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/theme-toggle.js
@@ -1,0 +1,29 @@
+(function () {
+  const root = document.documentElement;
+  const button = document.querySelector('.theme-toggle-btn');
+
+  function setIcon(theme) {
+    if (!button) return;
+    const icon = button.querySelector('i');
+    if (!icon) return;
+    icon.className = theme === 'dark' ? 'bi bi-sun-fill' : 'bi bi-moon-fill';
+  }
+
+  function applyTheme(theme) {
+    root.setAttribute('data-theme', theme);
+    setIcon(theme);
+  }
+
+  const savedTheme = localStorage.getItem('theme');
+  const initialTheme = savedTheme || 'light';
+  applyTheme(initialTheme);
+
+  if (button) {
+    button.addEventListener('click', function () {
+      const currentTheme = root.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+      const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
+      applyTheme(nextTheme);
+      localStorage.setItem('theme', nextTheme);
+    });
+  }
+})();

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/kali-uchis.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/kali-uchis.html
@@ -159,6 +159,9 @@
     </style>
 </head>
 <body class="d-flex flex-column h-100">
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+  <i class="bi bi-moon-fill"></i>
+</button>
 <main class="flex-shrink-0">
     <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
         <div class="container px-5">
@@ -234,5 +237,6 @@
 </footer>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="js/scripts.js"></script>
+    <script src="js/theme-toggle.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/poder-mentira.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/poder-mentira.html
@@ -162,6 +162,9 @@
     </style>
 </head>
 <body class="d-flex flex-column h-100">
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+  <i class="bi bi-moon-fill"></i>
+</button>
 <main class="flex-shrink-0">
     <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
         <div class="container px-5">
@@ -245,5 +248,6 @@
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="js/scripts.js"></script>
+    <script src="js/theme-toggle.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/projects.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/projects.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="light">
+<html lang="es" data-theme="light">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
@@ -170,6 +170,9 @@
     </style>
 </head>
 <body class="d-flex flex-column h-100 bg-light">
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+  <i class="bi bi-moon-fill"></i>
+</button>
 <main class="flex-shrink-0">
     <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
         <div class="container px-5">
@@ -275,5 +278,6 @@
 </footer>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="js/scripts.js"></script>
+    <script src="js/theme-toggle.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/resume.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/resume.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="light">
+<html lang="es" data-theme="light">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
@@ -165,6 +165,9 @@
         </style>
 </head>
 <body class="d-flex flex-column h-100 bg-light">
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+  <i class="bi bi-moon-fill"></i>
+</button>
     <main class="flex-shrink-0">
         <!-- Navigation-->
         <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
@@ -364,5 +367,6 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Core theme JS-->
     <script src="js/scripts.js"></script>
+    <script src="js/theme-toggle.js"></script>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/salomon.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/salomon.html
@@ -172,6 +172,9 @@
     </style>
 </head>
 <body class="d-flex flex-column h-100">
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+  <i class="bi bi-moon-fill"></i>
+</button>
 <main class="flex-shrink-0">
     <!-- NAVBAR -->
     <nav class="navbar navbar-expand-lg py-3">
@@ -275,5 +278,6 @@
 
 
 
+    <script src="js/theme-toggle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Make light mode the default theme across the whole site and provide a single shared UI to toggle between light and dark.
- Ensure the theme preference is persisted and the toggle UI is consistent across root and diary pages.

### Description
- Updated every HTML file to use `<html lang="es" data-theme="light">` so light mode is the default and language is set to Spanish.
- Inserted the toggle button markup `<button class="theme-toggle-btn" aria-label="Cambiar tema"><i class="bi bi-moon-fill"></i></button>` immediately after each opening `<body>` tag across all pages, including those in `diary/`.
- Added a shared script `js/theme-toggle.js` that on load reads `localStorage.getItem('theme')` (defaults to `'light'`), applies it to `document.documentElement` via `data-theme`, toggles between `'light'` and `'dark'` on `.theme-toggle-btn` clicks, persists the value to `localStorage`, and switches the button icon class between `bi-moon-fill` and `bi-sun-fill`.
- Appended a `script` include for `js/theme-toggle.js` before `</body>` on every page and removed per-page `dark-mode.js` includes in diary pages to avoid conflicts.
- Added the `.theme-toggle-btn` CSS block under `/* === Theme Toggle Button === */` in `css/styles.css` implementing the fixed circular button, backdrop blur, border, color rules for light/dark, mobile offset, and smooth transitions.

### Testing
- Ran the automated test `node --test tests/word-cycle.test.js` which passed successfully.
- Executed an internal verification script that checked each HTML file contains `'<html lang="es" data-theme="light">'`, the `.theme-toggle-btn` markup, a `theme-toggle.js` include before `</body>`, and no remaining `dark-mode.js` includes, and the script reported all files OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91fe03f408324b188a0dc8dd1cf8c)