### PR TITLE
Use theme CSS variables for project preview and diary pages

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -12585,18 +12585,24 @@ body {
   -webkit-box-orient: vertical;
 }
 
-.diary-page { background: #171717; color: #eaeaea; --bg-color:#171717; --text-color:#eaeaea; --nav-link-color:#ffa94d; }
+.diary-page { background-color: var(--bg-color); color: var(--text-color); }
 .diary-header { margin: 24px 0 8px; font-weight: 700; }
 .diary-month { margin: 40px 0 16px; font-weight: 600; font-size: 1.125rem; color:#cfcfcf;}
 .diary-grid { display:grid; grid-template-columns:1fr; gap:20px; }
 @media(min-width: 900px){ .diary-grid { grid-template-columns:1fr 1fr; } }
-.diary-card { background:#222; border-radius:14px; box-shadow:0 6px 18px rgba(0,0,0,.25); padding:20px; }
+.diary-card { background-color: var(--section-bg-light); color: var(--text-color); border-radius:14px; box-shadow:0 6px 18px rgba(0,0,0,.25); padding:20px; }
 .diary-card h3 { margin:0 0 6px; font-size:1.25rem; line-height:1.3; }
 .diary-card h3 a, .diary-featured h2 a { color:#ffa94d; text-decoration:none; }
 .diary-card h3 a:hover, .diary-featured h2 a:hover { color:#ffa94d; }
 .diary-date { color:#9aa0a6; font-size:.9rem; margin-bottom:8px; }
 .diary-excerpt { display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical; overflow:hidden; color:#d6d6d6; }
-.diary-featured { margin:32px 0; padding:28px; background:#1f1f1f; border-radius:16px; }
+.diary-featured { margin:32px 0; padding:28px; background-color: var(--section-bg-light); color: var(--text-color); border-radius:16px; }
+.diary-page .navbar-dark {
+  background-color: var(--bg-color) !important;
+  --bs-navbar-color: var(--text-color);
+  --bs-navbar-hover-color: var(--nav-link-color);
+  --bs-navbar-active-color: var(--nav-link-color);
+}
 .diary-cta { display:inline-block; margin-top:12px; padding:8px 14px; border:1px solid #888; border-radius:10px; text-decoration:none; color:#eaeaea; }
 .diary-cta:hover { border-color:#bbb; }
 @media (hover:hover) and (pointer:fine) {

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/index.html
@@ -47,7 +47,7 @@
 
         <section id="diary-featured"></section>
         <div id="diary-list"></div>
-        <p id="diary-empty" style="display:none;color:#9aa0a6;">No entries found for that search.</p>
+        <p id="diary-empty" style="display:none;color:var(--muted-text-color);">No entries found for that search.</p>
 
         <div class="text-center my-5">
             <a class="diary-cta" href="../index.html">Volver al inicio</a>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
@@ -157,7 +157,7 @@
 
     /* ===== Adelanto de proyectos ===== */
     .project-preview-section {
-      background-color: #000;
+      background-color: var(--bg-color);
     }
     .project-grid {
       display: grid;


### PR DESCRIPTION
### Motivation
- Replace hardcoded dark colors that ignored the theme variables so diary pages and the project preview respect the global light/dark theme and variable overrides.
- Ensure diary cards, featured diary blocks and navbar on diary pages use the same CSS variables so dark mode looks consistent and maintainable.

### Description
- Replaced the home page `.project-preview-section` hardcoded `#000` with `background-color: var(--bg-color)` in `index.html`.
- Replaced hardcoded diary colors in `css/styles.css` so `.diary-page` uses `background-color: var(--bg-color)` and `color: var(--text-color)`, and `.diary-card` / `.diary-featured` use `background-color: var(--section-bg-light)` and `color: var(--text-color)`.
- Added diary-specific navbar overrides under `.diary-page .navbar-dark` to make the diary navbar follow `var(--bg-color)`, `var(--text-color)`, and `var(--nav-link-color)`.
- Replaced the inline hardcoded empty-state color in `diary/index.html` with `var(--muted-text-color)`.

### Testing
- Searched diary HTML files for inline or `<style>` hardcoded `background`, `background-color`, or `color` declarations using `rg` and confirmed only variable-based styles remain for the diary pages, which succeeded.
- Ran `git diff --check` to validate there are no whitespace/patch issues, which returned clean results.
- Verified the three modified files are updated: `index.html`, `css/styles.css`, and `diary/index.html`, and the automated checks above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e924b981888324bee42536b54df0d2)