### PR TITLE
Replace hardcoded diary & project preview colors with theme variables; add dark-mode overrides

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -12325,6 +12325,24 @@ body {
   border-bottom: 2px solid #ffa500 !important;
 }
 
+
+[data-theme="dark"] .project-preview-section {
+  background-color: #000;
+}
+[data-theme="dark"] .diary-card {
+  background-color: #222;
+}
+[data-theme="dark"] .diary-featured {
+  background-color: #1f1f1f;
+}
+[data-theme="dark"] .diary-date,
+[data-theme="dark"] .diary-month {
+  color: #9aa0a6;
+}
+[data-theme="dark"] .diary-excerpt {
+  color: #d6d6d6;
+}
+
 /* Carrusel de proyectos - Versión móvil */
 @media (max-width: 767px) {
   /* Contenedor principal - aseguramos que el swiper tenga el comportamiento correcto */
@@ -12587,15 +12605,15 @@ body {
 
 .diary-page { background-color: var(--bg-color); color: var(--text-color); }
 .diary-header { margin: 24px 0 8px; font-weight: 700; }
-.diary-month { margin: 40px 0 16px; font-weight: 600; font-size: 1.125rem; color:#cfcfcf;}
+.diary-month { margin: 40px 0 16px; font-weight: 600; font-size: 1.125rem; color: var(--muted-text-color);}
 .diary-grid { display:grid; grid-template-columns:1fr; gap:20px; }
 @media(min-width: 900px){ .diary-grid { grid-template-columns:1fr 1fr; } }
-.diary-card { background-color: var(--section-bg-light); color: var(--text-color); border-radius:14px; box-shadow:0 6px 18px rgba(0,0,0,.25); padding:20px; }
+.diary-card { background-color: var(--section-bg-light); color: var(--text-color); border: 1px solid rgba(128,128,128,0.15); border-radius:14px; box-shadow:0 6px 18px rgba(0,0,0,.25); padding:20px; }
 .diary-card h3 { margin:0 0 6px; font-size:1.25rem; line-height:1.3; }
 .diary-card h3 a, .diary-featured h2 a { color:#ffa94d; text-decoration:none; }
 .diary-card h3 a:hover, .diary-featured h2 a:hover { color:#ffa94d; }
-.diary-date { color:#9aa0a6; font-size:.9rem; margin-bottom:8px; }
-.diary-excerpt { display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical; overflow:hidden; color:#d6d6d6; }
+.diary-date { color: var(--muted-text-color); font-size:.9rem; margin-bottom:8px; }
+.diary-excerpt { display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical; overflow:hidden; color: var(--text-color); }
 .diary-featured { margin:32px 0; padding:28px; background-color: var(--section-bg-light); color: var(--text-color); border-radius:16px; }
 .diary-page .navbar-dark {
   background-color: var(--bg-color) !important;

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
@@ -157,7 +157,7 @@
 
     /* ===== Adelanto de proyectos ===== */
     .project-preview-section {
-      background-color: var(--bg-color);
+      background-color: var(--section-bg-light);
     }
     .project-grid {
       display: grid;
@@ -212,12 +212,12 @@
       opacity: 1;
     }
     .project-card-preview h3 {
-      color: #fff;
+      color: var(--text-color);
       font-size: 1.25rem;
       margin-bottom: 0.5rem;
     }
     .project-card-preview p {
-      color: #ccc;
+      color: var(--muted-text-color);
       font-size: 0.9rem;
     }
 


### PR DESCRIPTION
### Motivation
- Remove remaining hardcoded dark colors in the diary and project preview areas that caused readability regressions and prevent theme switching from working correctly. 
- Restore a consistent, variable-driven theming approach so light/dark modes use `--*` variables and the intended dark appearance is preserved via explicit dark-mode overrides.

### Description
- Replaced hardcoded diary colors in `startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css` so `.diary-page`, `.diary-card`, `.diary-featured`, `.diary-date`, `.diary-excerpt`, and `.diary-month` use CSS variables and added a subtle border to `.diary-card`.
- Added dark-mode overrides in `css/styles.css` under `[data-theme="dark"]` to restore the original dark look for `.project-preview-section`, `.diary-card`, `.diary-featured`, `.diary-date`/`.diary-month`, and `.diary-excerpt`.
- Updated inline styles in `startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html` so `.project-preview-section` uses `var(--section-bg-light)` and `.project-card-preview h3`/`p` use `var(--text-color)` and `var(--muted-text-color)` respectively.
- Verified diary post pages under `diary/` do not contain matching inline `<style>` blocks with the reported hardcoded dark values so no per-post edits were required.

### Testing
- Ran targeted pattern searches with `rg` to locate diary/project style rules and dark hex values which confirmed the updated variable usage and presence of the new dark-mode overrides (searches returned the updated lines). — succeeded.
- Inspected the diff with `git diff` and committed the changes with `git commit` to ensure the two modified files (`css/styles.css` and `index.html`) contain the expected replacements. — commit succeeded.
- Ran a check for inline hardcoded colors in `startbootstrap-personal-gh-pages/.../diary` using `rg` which returned no matching inline hardcoded diary color blocks. — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92623ce948324a25092c73a295519)