### PR TITLE
Add classes to diary teaser links and append CSS overrides

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -12780,3 +12780,35 @@ footer a.small:hover {
     right: 0.75rem;
   }
 }
+
+
+/* Diary teaser - títulos de artículos */
+#diary-teaser a.diary-title-link {
+  color: #ff6600 !important;
+  text-decoration: none;
+}
+#diary-teaser a.diary-title-link:hover {
+  color: #000000 !important;
+}
+
+/* Diary teaser - enlaces Leer más */
+#diary-teaser a.leer-mas-link {
+  color: #ff6600 !important;
+  text-decoration: none;
+  font-weight: 600;
+}
+#diary-teaser a.leer-mas-link:hover {
+  color: #000000 !important;
+}
+
+/* Botón Leer el diario completo */
+.btn-outline-dark {
+  color: #ff6600 !important;
+  border-color: #ff6600 !important;
+  background-color: transparent;
+}
+.btn-outline-dark:hover {
+  background-color: #000000 !important;
+  color: #ff6600 !important;
+  border-color: #000000 !important;
+}

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diary-teaser.js
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diary-teaser.js
@@ -13,6 +13,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     const h3 = document.createElement("h3");
     const link = document.createElement("a");
+    link.className = "diary-title-link";
     link.href = `/diary/${entry.date.slice(0, 4)}/${entry.date.slice(5, 7)}/${entry.slug}/`;
     link.textContent = entry.title;
     h3.appendChild(link);
@@ -33,7 +34,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     article.appendChild(p);
 
     const cta = document.createElement("a");
-    cta.className = "diary-cta";
+    cta.className = "diary-cta leer-mas-link";
     cta.href = link.href;
     cta.textContent = "Leer más";
     article.appendChild(cta);


### PR DESCRIPTION
### Motivation
- Ensure diary post titles and the “Leer más” links inside `#diary-teaser` have stable class selectors so they can be targeted by CSS rules.
- Provide the requested color, hover and button styles for the diary teaser links and the `.btn-outline-dark` variant without using inline styles.

### Description
- Add `link.className = "diary-title-link"` to the generated title anchor in `js/diary-teaser.js` so title anchors receive the `diary-title-link` class.
- Add `leer-mas-link` to the generated CTA anchor in `js/diary-teaser.js` while preserving the existing `diary-cta` class (result: `"diary-cta leer-mas-link"`).
- Append the provided CSS block to the end of `css/styles.css` implementing rules for `#diary-teaser a.diary-title-link`, `#diary-teaser a.leer-mas-link` and `.btn-outline-dark` and their hover states.

### Testing
- Verified the changes with `git diff -- startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/diary-teaser.js startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css` which showed the intended modifications.
- Inspected the modified files with `nl -ba` and `tail` to confirm the class additions and appended CSS block were correctly written.
- Committed the changes with `git commit` and confirmed repository status with `git status --short` and `git rev-parse --short HEAD`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea99e905588324a7976fb3fe54b5c5)