### PR TITLE
Fix mobile project preview background and reposition theme toggle FAB

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/arte-naturaleza.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/arte-naturaleza.html
@@ -49,32 +49,6 @@
             padding: 2rem;
         }
 
-        /* Estilo del botón de cambio de tema */
-            position: fixed;
-            top: 1.5rem;
-            right: 1.5rem;
-            background: rgba(255, 255, 255, 0.1);
-            border: none;
-            border-radius: 8px;
-            width: 36px;
-            height: 36px;
-            font-size: 1.2rem;
-            color: var(--text-color);
-            cursor: pointer;
-            z-index: 999;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-        @media (max-width: 767px) {
-                top: 4rem;
-                right: 1rem;
-                width: 32px;
-                height: 32px;
-                font-size: 1rem;
-            }
-        }
-
         /* Ajustes para el menú desplegable */
         .navbar-collapse {
             z-index: 1000;

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/contact.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/contact.html
@@ -53,32 +53,6 @@
             background-color: var(--section-bg-light) !important;
         }
 
-        /* Estilo del botón de cambio de tema */
-            position: fixed;
-            top: 1.5rem;
-            right: 1.5rem;
-            background: rgba(255, 255, 255, 0.1);
-            border: none;
-            border-radius: 8px;
-            width: 36px;
-            height: 36px;
-            font-size: 1.2rem;
-            color: var(--text-color);
-            cursor: pointer;
-            z-index: 999;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-        @media (max-width: 767px) {
-                top: 4rem;
-                right: 1rem;
-                width: 32px;
-                height: 32px;
-                font-size: 1rem;
-            }
-        }
-
         /* Ajustes para el menú desplegable */
         .navbar-collapse {
             z-index: 1000;

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -11861,35 +11861,6 @@ html {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3); /* Sombra más pronunciada al pasar el cursor */
 }
 
-/* Estilo del botón de cambio de tema */
-.theme-toggle {
-  position: fixed;
-  top: 1.5rem;
-  right: 1.5rem;
-  background: rgba(255, 255, 255, 0.1);
-  border: none;
-  border-radius: 8px;
-  width: 36px;
-  height: 36px;
-  font-size: 1.2rem;
-  color: var(--text-color);
-  cursor: pointer;
-  z-index: 999;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-@media (max-width: 767px) {
-  .theme-toggle {
-    top: 4rem;
-    right: 1rem;
-    width: 32px;
-    height: 32px;
-    font-size: 1rem;
-  }
-}
-
 /* Ajustes para el menú desplegable */
 .navbar-collapse {
   z-index: 1000;
@@ -12070,25 +12041,6 @@ body {
 
 .bg-light {
   background-color: var(--section-bg-light) !important;
-}
-
-/* (Si usas un botón flotante para tema) */
-.theme-toggle {
-  position: fixed;
-  top: 1.5rem;
-  right: 1.5rem;
-  background: rgba(255, 255, 255, 0.1);
-  border: none;
-  border-radius: 8px;
-  width: 36px;
-  height: 36px;
-  font-size: 1.2rem;
-  color: var(--text-color);
-  cursor: pointer;
-  z-index: 999;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 /* ======================
@@ -12326,8 +12278,12 @@ body {
 }
 
 
+.project-preview-section {
+  background-color: var(--section-bg-light) !important;
+}
+
 [data-theme="dark"] .project-preview-section {
-  background-color: #000;
+  background-color: #000 !important;
 }
 [data-theme="dark"] .diary-card {
   background-color: #222;
@@ -12749,38 +12705,44 @@ footer a.small:hover {
 /* === Theme Toggle Button === */
 .theme-toggle-btn {
   position: fixed;
-  top: 1rem;
-  right: 1rem;
-  z-index: 1000;
-  width: 40px;
-  height: 40px;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  top: auto;
+  z-index: 9999;
+  width: 48px;
+  height: 48px;
   border-radius: 50%;
-  display: inline-flex;
+  border: none;
+  background-color: #FF6600;
+  color: #ffffff;
+  font-size: 1.3rem;
+  display: flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  background: rgba(255, 255, 255, 0.15);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
-  color: #212529;
-  transition: all 0.3s ease;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+  transition: background-color 0.3s, transform 0.2s;
 }
 
-.theme-toggle-btn i {
-  pointer-events: none;
+.theme-toggle-btn:hover {
+  background-color: #e65c00;
+  transform: scale(1.08);
 }
 
 [data-theme="dark"] .theme-toggle-btn {
-  color: #f8f9fa;
+  background-color: #ffa94d;
+  color: #121212;
 }
 
 @media (max-width: 768px) {
   .theme-toggle-btn {
-    top: 4.5rem;
-    right: 0.75rem;
+    bottom: 1.2rem;
+    right: 1.2rem;
+    width: 44px;
+    height: 44px;
+    font-size: 1.1rem;
   }
 }
-
 
 /* Diary teaser - títulos de artículos */
 #diary-teaser a.diary-title-link {

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/gracias.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/gracias.html
@@ -49,32 +49,6 @@
             background-color: var(--section-bg-light) !important;
         }
 
-        /* Estilo del botón de cambio de tema */
-            position: fixed;
-            top: 1.5rem;
-            right: 1.5rem;
-            background: rgba(255, 255, 255, 0.1);
-            border: none;
-            border-radius: 8px;
-            width: 36px;
-            height: 36px;
-            font-size: 1.2rem;
-            color: var(--text-color);
-            cursor: pointer;
-            z-index: 999;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-        @media (max-width: 767px) {
-                top: 4rem;
-                right: 1rem;
-                width: 32px;
-                height: 32px;
-                font-size: 1rem;
-            }
-        }
-
         /* Ajustes para el menú desplegable */
         .navbar-collapse {
             z-index: 1000;

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
@@ -60,32 +60,6 @@
             background-color: var(--section-bg-light) !important;
         }
 
-        /* Estilo del botón de cambio de tema */
-            position: fixed;
-            top: 1.5rem;
-            right: 1.5rem;
-            background: rgba(255, 255, 255, 0.1);
-            border: none;
-            border-radius: 8px;
-            width: 36px;
-            height: 36px;
-            font-size: 1.2rem;
-            color: var(--text-color);
-            cursor: pointer;
-            z-index: 999;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-        @media (max-width: 767px) {
-                top: 4rem;
-                right: 1rem;
-                width: 32px;
-                height: 32px;
-                font-size: 1rem;
-            }
-        }
-
         /* Ajustes para el menú desplegable */
         .navbar-collapse {
             z-index: 1000;
@@ -157,7 +131,7 @@
 
     /* ===== Adelanto de proyectos ===== */
     .project-preview-section {
-      background-color: var(--section-bg-light);
+      background-color: var(--section-bg-light) !important;
     }
     .project-grid {
       display: grid;

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/poder-mentira.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/poder-mentira.html
@@ -53,32 +53,6 @@
             padding: 2rem;
         }
 
-        /* Estilo del botón de cambio de tema */
-            position: fixed;
-            top: 1.5rem;
-            right: 1.5rem;
-            background: rgba(255, 255, 255, 0.1);
-            border: none;
-            border-radius: 8px;
-            width: 36px;
-            height: 36px;
-            font-size: 1.2rem;
-            color: var(--text-color);
-            cursor: pointer;
-            z-index: 999;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-        @media (max-width: 767px) {
-                top: 4rem;
-                right: 1rem;
-                width: 32px;
-                height: 32px;
-                font-size: 1rem;
-            }
-        }
-
         /* Ajustes para el menú desplegable */
         .navbar-collapse {
             z-index: 1000;

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/projects.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/projects.html
@@ -49,32 +49,6 @@
             background-color: var(--section-bg-light) !important;
         }
 
-        /* Estilo del botón de cambio de tema */
-            position: fixed;
-            top: 1.5rem;
-            right: 1.5rem;
-            background: rgba(255, 255, 255, 0.1);
-            border: none;
-            border-radius: 8px;
-            width: 36px;
-            height: 36px;
-            font-size: 1.2rem;
-            color: var(--text-color);
-            cursor: pointer;
-            z-index: 999;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-        @media (max-width: 767px) {
-                top: 4rem;
-                right: 1rem;
-                width: 32px;
-                height: 32px;
-                font-size: 1rem;
-            }
-        }
-
         /* Ajustes para el menú desplegable */
         .navbar-collapse {
             z-index: 1000;

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/resume.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/resume.html
@@ -55,34 +55,6 @@
             background-color: var(--section-bg-light) !important;
         }
 
-        /* Estilo del botón de cambio de tema */
-        .theme-toggle {
-            position: fixed;
-            top: 1.5rem;
-            right: 1.5rem;
-            background: rgba(255, 255, 255, 0.1);
-            border: none;
-            border-radius: 8px;
-            width: 36px;
-            height: 36px;
-            font-size: 1.2rem;
-            color: var(--text-color);
-            cursor: pointer;
-            z-index: 999;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-        @media (max-width: 767px) {
-            .theme-toggle {
-                top: 4rem;
-                right: 1rem;
-                width: 32px;
-                height: 32px;
-                font-size: 1rem;
-            }
-        }
-
         /* Ajustes para el menú desplegable */
         .navbar-collapse {
             z-index: 1000;

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/salomon.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/salomon.html
@@ -47,32 +47,6 @@
             background-color: var(--bg-color);
         }
 
-        /* Estilo del botón de cambio de tema */
-            position: fixed;
-            top: 1.5rem;
-            right: 1.5rem;
-            background: rgba(255, 255, 255, 0.1); /* Fondo sutil para mejor visibilidad */
-            border: none; /* Eliminamos el borde circular */
-            border-radius: 8px; /* Bordes ligeramente redondeados */
-            width: 36px;
-            height: 36px;
-            font-size: 1.2rem;
-            color: var(--text-color);
-            cursor: pointer;
-            z-index: 999;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-        @media (max-width: 767px) {
-                top: 4rem; /* Bajamos el botón en pantallas pequeñas para evitar solapamiento con el menú */
-                right: 1rem;
-                width: 32px;
-                height: 32px;
-                font-size: 1rem;
-            }
-        }
-
         /* Ajustes para el menú desplegable */
         .navbar-collapse {
             z-index: 1000; /* Aseguramos que el menú esté por encima del botón de tema */


### PR DESCRIPTION
### Motivation

- Prevent the project preview section from rendering as a dark/black block on mobile by making the background rule authoritative, and stop the theme toggle button from overlapping the navbar on small screens by converting it to a floating action button.

### Description

- Updated the inline `<style>` in `index.html` so `.project-preview-section` uses `background-color: var(--section-bg-light) !important;` to override any conflicting rules.
- Added/normalized rules in `css/styles.css` to enforce `.project-preview-section { background-color: var(--section-bg-light) !important; }` and `[data-theme="dark"] .project-preview-section { background-color: #000 !important; }` so light/dark behavior is explicit.
- Replaced the previous top-right theme toggle positioning with a FAB-style `.theme-toggle-btn` in `css/styles.css` (fixed bottom-right, size, hover scale, dark variant, responsive mobile sizing) and removed per-page inline/embedded top/right theme-toggle blocks from HTML files so layout is controlled centrally.
- Verified `js/theme-toggle.js` sets the icon correctly: light theme → `<i class="bi bi-moon-fill"></i>`, dark theme → `<i class="bi bi-sun-fill"></i>` and left that logic unchanged.

### Testing

- Ran targeted searches with `rg` to confirm `index.html` and `css/styles.css` contain `background-color: var(--section-bg-light) !important;` and `[data-theme="dark"] .project-preview-section { background-color: #000 !important; }`, and these checks succeeded.
- Searched the HTML files for leftover inline `top:`/`right:` theme-toggle rules and confirmed the per-page inline positioning blocks were removed; the checks succeeded using `rg`/file inspections.
- Inspected `js/theme-toggle.js` to confirm the icon swap logic (`bi-moon-fill` for light, `bi-sun-fill` for dark) and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee462cb4108324bf383250b8059dc2)