### PR TITLE
Fix diary link colors and harden mobile theme toggle button

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -12566,8 +12566,25 @@ body {
 @media(min-width: 900px){ .diary-grid { grid-template-columns:1fr 1fr; } }
 .diary-card { background-color: var(--section-bg-light); color: var(--text-color); border: 1px solid rgba(128,128,128,0.15); border-radius:14px; box-shadow:0 6px 18px rgba(0,0,0,.25); padding:20px; }
 .diary-card h3 { margin:0 0 6px; font-size:1.25rem; line-height:1.3; }
-.diary-card h3 a, .diary-featured h2 a { color:#ffa94d; text-decoration:none; }
-.diary-card h3 a:hover, .diary-featured h2 a:hover { color:#ffa94d; }
+.diary-card h3 a,
+.diary-card h3 a:visited,
+.diary-card h3 a:hover,
+.diary-card h3 a:focus,
+.diary-featured h2 a,
+.diary-featured h2 a:visited,
+.diary-featured h2 a:hover,
+.diary-featured h2 a:focus,
+#diary-teaser a,
+#diary-teaser h3 a,
+#diary-teaser h2 a {
+  color: #FF6600 !important;
+  text-decoration: none !important;
+}
+
+#diary-teaser a:hover {
+  color: #FFA500 !important;
+  text-decoration: underline !important;
+}
 .diary-date { color: var(--muted-text-color); font-size:.9rem; margin-bottom:8px; }
 .diary-excerpt { display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical; overflow:hidden; color: var(--text-color); }
 .diary-featured { margin:32px 0; padding:28px; background-color: var(--section-bg-light); color: var(--text-color); border-radius:16px; }
@@ -12704,23 +12721,29 @@ footer a.small:hover {
 
 /* === Theme Toggle Button === */
 .theme-toggle-btn {
-  position: fixed;
-  bottom: 1.5rem;
-  right: 1.5rem;
-  top: auto;
-  z-index: 9999;
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  border: none;
-  background-color: #FF6600;
-  color: #ffffff;
-  font-size: 1.3rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+  position: fixed !important;
+  bottom: 1.5rem !important;
+  right: 1.5rem !important;
+  top: auto !important;
+  left: auto !important;
+  z-index: 99999 !important;
+  width: 48px !important;
+  height: 48px !important;
+  min-width: 48px !important;
+  min-height: 48px !important;
+  border-radius: 50% !important;
+  border: none !important;
+  background-color: #FF6600 !important;
+  color: #ffffff !important;
+  font-size: 1.3rem !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  cursor: pointer !important;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.25) !important;
+  padding: 0 !important;
+  line-height: 1 !important;
+  overflow: visible !important;
   transition: background-color 0.3s, transform 0.2s;
 }
 
@@ -12736,32 +12759,11 @@ footer a.small:hover {
 
 @media (max-width: 768px) {
   .theme-toggle-btn {
-    bottom: 1.2rem;
-    right: 1.2rem;
-    width: 44px;
-    height: 44px;
-    font-size: 1.1rem;
+    bottom: 1.2rem !important;
+    right: 1.2rem !important;
   }
 }
 
-/* Diary teaser - títulos de artículos */
-#diary-teaser a.diary-title-link {
-  color: #ff6600 !important;
-  text-decoration: none;
-}
-#diary-teaser a.diary-title-link:hover {
-  color: #000000 !important;
-}
-
-/* Diary teaser - enlaces Leer más */
-#diary-teaser a.leer-mas-link {
-  color: #ff6600 !important;
-  text-decoration: none;
-  font-weight: 600;
-}
-#diary-teaser a.leer-mas-link:hover {
-  color: #000000 !important;
-}
 
 /* Botón Leer el diario completo */
 .btn-outline-dark {

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/theme-toggle.js
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/theme-toggle.js
@@ -1,3 +1,13 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const btn = document.querySelector(".theme-toggle-btn");
+  if (btn) {
+    btn.style.removeProperty("display");
+    btn.style.removeProperty("visibility");
+    btn.style.removeProperty("top");
+    btn.style.removeProperty("left");
+  }
+});
+
 (function () {
   const root = document.documentElement;
   const button = document.querySelector('.theme-toggle-btn');


### PR DESCRIPTION
### Motivation
- Diary entry titles were inheriting Bootstrap link color and showing blue instead of the intended orange, and teaser links needed consistent hover behavior. 
- The floating theme toggle button could be hidden, clipped, or lose its circular shape on mobile due to competing CSS or inline properties. 

### Description
- Updated `css/styles.css` to expand the diary link selectors (including `:visited`, `:hover`, and `:focus`) and added `!important` orange color and text-decoration rules for diary cards, featured headings, and teaser links, plus the requested hover color/underline rules. 
- Removed the old diary-teaser-specific link rules that conflicted with the unified diary link styling so teaser-generated links inherit the corrected styles. 
- Strengthened the `.theme-toggle-btn` rule in `css/styles.css` to use `!important` on positioning, size, stacking, and visual properties and ensured `left: auto` is present so the rule only uses `bottom`/`right`. 
- Prepended a safeguard in `js/theme-toggle.js` that runs on `DOMContentLoaded` and removes any inline `display`, `visibility`, `top`, and `left` properties from `.theme-toggle-btn` so the button cannot be accidentally hidden or clipped. 
- Verified `js/diary-teaser.js` does not set inline color styles for diary title links so CSS controls the color. 

### Testing
- Ran `git diff --check` and it reported no check failures. 
- Searched the codebase with ripgrep (`rg`) for `.theme-toggle-btn`, diary teaser/link selectors, and inline `style=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee710ad17c8324be3b8c21dd88146b)