### PR TITLE
Move theme toggle button to end of body across all HTML pages

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/arte-naturaleza.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/arte-naturaleza.html
@@ -100,9 +100,6 @@
     </style>
 </head>
 <body class="d-flex flex-column h-100">
-<button class="theme-toggle-btn" aria-label="Cambiar tema">
-  <i class="bi bi-moon-fill"></i>
-</button>
 <main class="flex-shrink-0">
     <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
         <div class="container px-5">
@@ -194,5 +191,9 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="js/scripts.js"></script>
     <script src="js/theme-toggle.js"></script>
+
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+    <i class="bi bi-moon-fill"></i>
+</button>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/contact.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/contact.html
@@ -95,9 +95,6 @@
     </style>
 </head>
 <body class="d-flex flex-column">
-<button class="theme-toggle-btn" aria-label="Cambiar tema">
-  <i class="bi bi-moon-fill"></i>
-</button>
     <main class="flex-shrink-0">
         <!-- Navigation-->
         <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
@@ -189,5 +186,9 @@
     <!-- SB Forms JS -->
     <script src="https://cdn.startbootstrap.com/sb-forms-latest.js"></script>
     <script src="js/theme-toggle.js"></script>
+
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+    <i class="bi bi-moon-fill"></i>
+</button>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/09/el-rico-es-rico-porque-es-rico/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/09/el-rico-es-rico-porque-es-rico/index.html
@@ -14,9 +14,6 @@
     <link href="../../../../css/styles.css" rel="stylesheet" />
 </head>
 <body class="diary-page">
-<button class="theme-toggle-btn" aria-label="Cambiar tema">
-  <i class="bi bi-moon-fill"></i>
-</button>
     <nav class="navbar navbar-expand-lg navbar-dark py-3">
         <div class="container px-5">
             <a class="navbar-brand" href="../../../../index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
@@ -60,5 +57,9 @@
     <script src="../../../../js/diary-utils.js"></script>
     <script src="../../../../js/diary-post.js"></script>
     <script src="../../../../js/theme-toggle.js"></script>
+
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+    <i class="bi bi-moon-fill"></i>
+</button>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/10/aun-estoy-a-tiempo/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/10/aun-estoy-a-tiempo/index.html
@@ -14,9 +14,6 @@
     <link href="../../../../css/styles.css" rel="stylesheet" />
 </head>
 <body class="diary-page">
-<button class="theme-toggle-btn" aria-label="Cambiar tema">
-  <i class="bi bi-moon-fill"></i>
-</button>
     <nav class="navbar navbar-expand-lg navbar-dark py-3">
         <div class="container px-5">
             <a class="navbar-brand" href="../../../../index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
@@ -60,5 +57,9 @@
     <script src="../../../../js/diary-utils.js"></script>
     <script src="../../../../js/diary-post.js"></script>
     <script src="../../../../js/theme-toggle.js"></script>
+
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+    <i class="bi bi-moon-fill"></i>
+</button>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/10/fotosintesis/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/10/fotosintesis/index.html
@@ -14,9 +14,6 @@
     <link href="../../../../css/styles.css" rel="stylesheet" />
 </head>
 <body class="diary-page">
-<button class="theme-toggle-btn" aria-label="Cambiar tema">
-  <i class="bi bi-moon-fill"></i>
-</button>
     <nav class="navbar navbar-expand-lg navbar-dark py-3">
         <div class="container px-5">
             <a class="navbar-brand" href="../../../../index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
@@ -60,5 +57,9 @@
     <script src="../../../../js/diary-utils.js"></script>
     <script src="../../../../js/diary-post.js"></script>
     <script src="../../../../js/theme-toggle.js"></script>
+
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+    <i class="bi bi-moon-fill"></i>
+</button>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/index.html
@@ -15,9 +15,6 @@
     <link href="../css/styles.css" rel="stylesheet" />
 </head>
 <body class="diary-page">
-<button class="theme-toggle-btn" aria-label="Cambiar tema">
-  <i class="bi bi-moon-fill"></i>
-</button>
     <nav class="navbar navbar-expand-lg navbar-dark py-3">
         <div class="container px-5">
             <a class="navbar-brand" href="../index.html"><span class="fw-bolder text-primary">Rick Grisales</span></a>
@@ -75,5 +72,9 @@
     <script src="../js/diary-utils.js"></script>
     <script src="../js/diary-index.js"></script>
     <script src="../js/theme-toggle.js"></script>
+
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+    <i class="bi bi-moon-fill"></i>
+</button>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/gracias.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/gracias.html
@@ -90,9 +90,6 @@
     </style>
 </head>
 <body class="d-flex flex-column h-100">
-<button class="theme-toggle-btn" aria-label="Cambiar tema">
-  <i class="bi bi-moon-fill"></i>
-</button>
     <main class="flex-shrink-0">
         <!-- Navigation -->
         <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
@@ -153,5 +150,9 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="js/scripts.js"></script>
     <script src="js/theme-toggle.js"></script>
+
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+    <i class="bi bi-moon-fill"></i>
+</button>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
@@ -233,9 +233,6 @@
     </style>
 </head>
 <body class="d-flex flex-column h-100">
-<button class="theme-toggle-btn" aria-label="Cambiar tema">
-  <i class="bi bi-moon-fill"></i>
-</button>
     <main class="flex-shrink-0">
         <!-- Navigation-->
         <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
@@ -423,5 +420,9 @@
     <script src="js/word-cycle.js"></script>
 
     <script src="js/theme-toggle.js"></script>
+
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+    <i class="bi bi-moon-fill"></i>
+</button>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/kali-uchis.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/kali-uchis.html
@@ -159,9 +159,6 @@
     </style>
 </head>
 <body class="d-flex flex-column h-100">
-<button class="theme-toggle-btn" aria-label="Cambiar tema">
-  <i class="bi bi-moon-fill"></i>
-</button>
 <main class="flex-shrink-0">
     <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
         <div class="container px-5">
@@ -238,5 +235,9 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="js/scripts.js"></script>
     <script src="js/theme-toggle.js"></script>
+
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+    <i class="bi bi-moon-fill"></i>
+</button>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/poder-mentira.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/poder-mentira.html
@@ -136,9 +136,6 @@
     </style>
 </head>
 <body class="d-flex flex-column h-100">
-<button class="theme-toggle-btn" aria-label="Cambiar tema">
-  <i class="bi bi-moon-fill"></i>
-</button>
 <main class="flex-shrink-0">
     <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
         <div class="container px-5">
@@ -223,5 +220,9 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="js/scripts.js"></script>
     <script src="js/theme-toggle.js"></script>
+
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+    <i class="bi bi-moon-fill"></i>
+</button>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/projects.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/projects.html
@@ -144,9 +144,6 @@
     </style>
 </head>
 <body class="d-flex flex-column h-100 bg-light">
-<button class="theme-toggle-btn" aria-label="Cambiar tema">
-  <i class="bi bi-moon-fill"></i>
-</button>
 <main class="flex-shrink-0">
     <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
         <div class="container px-5">
@@ -253,5 +250,9 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="js/scripts.js"></script>
     <script src="js/theme-toggle.js"></script>
+
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+    <i class="bi bi-moon-fill"></i>
+</button>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/resume.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/resume.html
@@ -137,9 +137,6 @@
         </style>
 </head>
 <body class="d-flex flex-column h-100 bg-light">
-<button class="theme-toggle-btn" aria-label="Cambiar tema">
-  <i class="bi bi-moon-fill"></i>
-</button>
     <main class="flex-shrink-0">
         <!-- Navigation-->
         <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
@@ -340,5 +337,9 @@
     <!-- Core theme JS-->
     <script src="js/scripts.js"></script>
     <script src="js/theme-toggle.js"></script>
+
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+    <i class="bi bi-moon-fill"></i>
+</button>
 </body>
 </html>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/salomon.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/salomon.html
@@ -146,9 +146,6 @@
     </style>
 </head>
 <body class="d-flex flex-column h-100">
-<button class="theme-toggle-btn" aria-label="Cambiar tema">
-  <i class="bi bi-moon-fill"></i>
-</button>
 <main class="flex-shrink-0">
     <!-- NAVBAR -->
     <nav class="navbar navbar-expand-lg py-3">
@@ -253,5 +250,9 @@
 
 
     <script src="js/theme-toggle.js"></script>
+
+<button class="theme-toggle-btn" aria-label="Cambiar tema">
+    <i class="bi bi-moon-fill"></i>
+</button>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- The theme toggle button was rendered near the top of `<body>` and inside the navbar flow on mobile, causing it to be captured by layout elements and preventing `position: fixed` from working correctly. 
- The intent is to make the toggle an independent, fixed element by ensuring it is a direct child of `<body>` and placed immediately before `</body>` on every page. 
- Preserve existing CSS/JS behavior and correct script paths for nested pages while only relocating the button markup. 

### Description
- Removed the existing `<button class="theme-toggle-btn" aria-label="Cambiar tema">…</button>` from the top/body-start area and inserted it immediately before `</body>` in each HTML file. 
- Applied the change across 13 HTML files under `startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages`, including pages in the `diary/` subdirectories. 
- Kept all `script` tags intact and preserved relative paths to `js/theme-toggle.js` for nested diary pages (e.g. `../js/theme-toggle.js` or deeper `../../../../js/theme-toggle.js`). 
- No CSS or JavaScript logic was modified. 

### Testing
- Ran `rg --files -g '*.html'` to enumerate HTML files and `rg -n "theme-toggle-btn|theme-toggle.js|</body>|<body"` to verify button/script locations, and the outputs showed the button moved to the end of each file. 
- Executed the relocation script and a Python validation script that confirmed each HTML file contains exactly one `.theme-toggle-btn` and it appears immediately before `</body>`, and validation returned OK. 
- Verified the changes with additional `nl`/`rg` checks to inspect line positions of `theme-toggle.js`, `.theme-toggle-btn` and `</body>`, and those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee73ef41248324b07280cb8de1eed7)