### PR TITLE
Add sitewide Spanish/English language toggle

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/arte-naturaleza.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/arte-naturaleza.html
@@ -109,11 +109,11 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
-                    <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-                    <li class="nav-item"><a class="nav-link" href="resume.html">Resumen - CV</a></li>
-                    <li class="nav-item"><a class="nav-link" href="projects.html">Proyectos</a></li>
-                    <li class="nav-item"><a class="nav-link" href="diary/">Diario de un escritor perdido</a></li>
-                    <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
+                    <li class="nav-item"><a class="nav-link" href="index.html" data-es="Home" data-en="Home">Home</a></li>
+                    <li class="nav-item"><a class="nav-link" href="resume.html" data-es="Resumen - CV" data-en="Resume - CV">Resumen - CV</a></li>
+                    <li class="nav-item"><a class="nav-link" href="projects.html" data-es="Proyectos" data-en="Projects">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="diary/" data-es="Diario de un escritor perdido" data-en="Diary of a lost writer">Diario de un escritor perdido</a></li>
+                    <li class="nav-item"><a class="nav-link" href="contact.html" data-es="Contacto" data-en="Contact">Contacto</a></li>
                 </ul>
             </div>
         </div>
@@ -178,11 +178,11 @@
         <div class="row align-items-center justify-content-between flex-column flex-sm-row">
             <div class="col-auto"><div class="small m-0">Copyright © Rick 2025</div></div>
             <div class="col-auto">
-                <a class="small" href="#!">Privacidad</a>
+                <a class="small" href="#!" data-es="Privacidad" data-en="Privacy">Privacidad</a>
                 <span class="mx-1">·</span>
-                <a class="small" href="#!">Términos</a>
+                <a class="small" href="#!" data-es="Términos" data-en="Terms">Términos</a>
                 <span class="mx-1">·</span>
-                <a class="small" href="contact.html">Contacto</a>
+                <a class="small" href="contact.html" data-es="Contacto" data-en="Contact">Contacto</a>
             </div>
         </div>
     </div>
@@ -191,7 +191,9 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="js/scripts.js"></script>
     <script src="js/theme-toggle.js"></script>
+    <script src="js/lang-toggle.js"></script>
 
+<button class="lang-toggle-btn" aria-label="Cambiar idioma">EN</button>
 <button class="theme-toggle-btn" aria-label="Cambiar tema">
     <i class="bi bi-moon-fill"></i>
 </button>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/contact.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/contact.html
@@ -107,11 +107,11 @@
                 </button>
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
-                        <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-                        <li class="nav-item"><a class="nav-link" href="resume.html">Resumen - CV</a></li>
-                        <li class="nav-item"><a class="nav-link" href="projects.html">Proyectos</a></li>
-                    <li class="nav-item"><a class="nav-link" href="diary/">Diario de un escritor perdido</a></li>
-                        <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
+                        <li class="nav-item"><a class="nav-link" href="index.html" data-es="Home" data-en="Home">Home</a></li>
+                        <li class="nav-item"><a class="nav-link" href="resume.html" data-es="Resumen - CV" data-en="Resume - CV">Resumen - CV</a></li>
+                        <li class="nav-item"><a class="nav-link" href="projects.html" data-es="Proyectos" data-en="Projects">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="diary/" data-es="Diario de un escritor perdido" data-en="Diary of a lost writer">Diario de un escritor perdido</a></li>
+                        <li class="nav-item"><a class="nav-link" href="contact.html" data-es="Contacto" data-en="Contact">Contacto</a></li>
                     </ul>
                 </div>
             </div>
@@ -155,7 +155,7 @@
                                 <input type="hidden" name="_captcha" value="false">
                                 <!-- Submit Button -->
                                 <div class="d-grid">
-                                    <button class="btn btn-primary btn-lg" type="submit">Enviar</button>
+                                    <button class="btn btn-primary btn-lg" type="submit" data-es="Enviar" data-en="Send">Enviar</button>
                                 </div>
                             </form>
                         </div>
@@ -170,11 +170,11 @@
             <div class="row align-items-center justify-content-between flex-column flex-sm-row">
                 <div class="col-auto"><div class="small m-0">Copyright © Rick 2025</div></div>
                 <div class="col-auto">
-                    <a class="small" href="#!">Privacidad</a>
+                    <a class="small" href="#!" data-es="Privacidad" data-en="Privacy">Privacidad</a>
                     <span class="mx-1">·</span>
-                    <a class="small" href="#!">Términos</a>
+                    <a class="small" href="#!" data-es="Términos" data-en="Terms">Términos</a>
                     <span class="mx-1">·</span>
-                    <a class="small" href="#!">Contacto</a>
+                    <a class="small" href="#!" data-es="Contacto" data-en="Contact">Contacto</a>
                 </div>
             </div>
         </div>
@@ -186,7 +186,9 @@
     <!-- SB Forms JS -->
     <script src="https://cdn.startbootstrap.com/sb-forms-latest.js"></script>
     <script src="js/theme-toggle.js"></script>
+    <script src="js/lang-toggle.js"></script>
 
+<button class="lang-toggle-btn" aria-label="Cambiar idioma">EN</button>
 <button class="theme-toggle-btn" aria-label="Cambiar tema">
     <i class="bi bi-moon-fill"></i>
 </button>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -12776,3 +12776,53 @@ footer a.small:hover {
   color: #ff6600 !important;
   border-color: #000000 !important;
 }
+
+/* === Language Toggle Button === */
+.lang-toggle-btn {
+  position: fixed !important;
+  bottom: 1.5rem !important;
+  right: 5.5rem !important;
+  top: auto !important;
+  left: auto !important;
+  z-index: 99999 !important;
+  width: 48px !important;
+  height: 48px !important;
+  border-radius: 50% !important;
+  border: 2px solid #FF6600 !important;
+  background-color: transparent !important;
+  color: #FF6600 !important;
+  font-size: 0.85rem !important;
+  font-weight: 700 !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  cursor: pointer !important;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15) !important;
+  padding: 0 !important;
+  font-family: 'Plus Jakarta Sans', sans-serif !important;
+  transition: all 0.3s !important;
+}
+
+.lang-toggle-btn:hover {
+  background-color: #FF6600 !important;
+  color: #ffffff !important;
+}
+
+[data-theme="dark"] .lang-toggle-btn {
+  border-color: #ffa94d !important;
+  color: #ffa94d !important;
+}
+
+[data-theme="dark"] .lang-toggle-btn:hover {
+  background-color: #ffa94d !important;
+  color: #121212 !important;
+}
+
+@media (max-width: 768px) {
+  .lang-toggle-btn {
+    bottom: 1.2rem !important;
+    right: 4.8rem !important;
+    width: 44px !important;
+    height: 44px !important;
+  }
+}

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/09/el-rico-es-rico-porque-es-rico/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/09/el-rico-es-rico-porque-es-rico/index.html
@@ -22,11 +22,11 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
-                    <li class="nav-item"><a class="nav-link" href="../../../../index.html">Home</a></li>
-                    <li class="nav-item"><a class="nav-link" href="../../../../resume.html">Resumen - CV</a></li>
-                    <li class="nav-item"><a class="nav-link" href="../../../../projects.html">Proyectos</a></li>
-                    <li class="nav-item"><a class="nav-link" href="../../../../diary/">Diario de un escritor perdido</a></li>
-                    <li class="nav-item"><a class="nav-link" href="../../../../contact.html">Contacto</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../../../../index.html" data-es="Home" data-en="Home">Home</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../../../../resume.html" data-es="Resumen - CV" data-en="Resume - CV">Resumen - CV</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../../../../projects.html" data-es="Proyectos" data-en="Projects">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../../../../diary/" data-es="Diario de un escritor perdido" data-en="Diary of a lost writer">Diario de un escritor perdido</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../../../../contact.html" data-es="Contacto" data-en="Contact">Contacto</a></li>
                 </ul>
             </div>
         </div>
@@ -41,11 +41,11 @@
             <div class="row align-items-center justify-content-between flex-column flex-sm-row">
                 <div class="col-auto"><div class="small m-0">Copyright © Rick 2025</div></div>
                 <div class="col-auto">
-                    <a class="small" href="#!">Privacidad</a>
+                    <a class="small" href="#!" data-es="Privacidad" data-en="Privacy">Privacidad</a>
                     <span class="mx-1">·</span>
-                    <a class="small" href="#!">Términos</a>
+                    <a class="small" href="#!" data-es="Términos" data-en="Terms">Términos</a>
                     <span class="mx-1">·</span>
-                    <a class="small" href="#!">Contacto</a>
+                    <a class="small" href="#!" data-es="Contacto" data-en="Contact">Contacto</a>
                 </div>
             </div>
         </div>
@@ -57,7 +57,9 @@
     <script src="../../../../js/diary-utils.js"></script>
     <script src="../../../../js/diary-post.js"></script>
     <script src="../../../../js/theme-toggle.js"></script>
+    <script src="../../../../js/lang-toggle.js"></script>
 
+<button class="lang-toggle-btn" aria-label="Cambiar idioma">EN</button>
 <button class="theme-toggle-btn" aria-label="Cambiar tema">
     <i class="bi bi-moon-fill"></i>
 </button>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/10/aun-estoy-a-tiempo/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/10/aun-estoy-a-tiempo/index.html
@@ -22,11 +22,11 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
-                    <li class="nav-item"><a class="nav-link" href="../../../../index.html">Home</a></li>
-                    <li class="nav-item"><a class="nav-link" href="../../../../resume.html">Resumen - CV</a></li>
-                    <li class="nav-item"><a class="nav-link" href="../../../../projects.html">Proyectos</a></li>
-                    <li class="nav-item"><a class="nav-link" href="../../../../diary/">Diario de un escritor perdido</a></li>
-                    <li class="nav-item"><a class="nav-link" href="../../../../contact.html">Contacto</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../../../../index.html" data-es="Home" data-en="Home">Home</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../../../../resume.html" data-es="Resumen - CV" data-en="Resume - CV">Resumen - CV</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../../../../projects.html" data-es="Proyectos" data-en="Projects">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../../../../diary/" data-es="Diario de un escritor perdido" data-en="Diary of a lost writer">Diario de un escritor perdido</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../../../../contact.html" data-es="Contacto" data-en="Contact">Contacto</a></li>
                 </ul>
             </div>
         </div>
@@ -41,11 +41,11 @@
             <div class="row align-items-center justify-content-between flex-column flex-sm-row">
                 <div class="col-auto"><div class="small m-0">Copyright © Rick 2025</div></div>
                 <div class="col-auto">
-                    <a class="small" href="#!">Privacidad</a>
+                    <a class="small" href="#!" data-es="Privacidad" data-en="Privacy">Privacidad</a>
                     <span class="mx-1">·</span>
-                    <a class="small" href="#!">Términos</a>
+                    <a class="small" href="#!" data-es="Términos" data-en="Terms">Términos</a>
                     <span class="mx-1">·</span>
-                    <a class="small" href="#!">Contacto</a>
+                    <a class="small" href="#!" data-es="Contacto" data-en="Contact">Contacto</a>
                 </div>
             </div>
         </div>
@@ -57,7 +57,9 @@
     <script src="../../../../js/diary-utils.js"></script>
     <script src="../../../../js/diary-post.js"></script>
     <script src="../../../../js/theme-toggle.js"></script>
+    <script src="../../../../js/lang-toggle.js"></script>
 
+<button class="lang-toggle-btn" aria-label="Cambiar idioma">EN</button>
 <button class="theme-toggle-btn" aria-label="Cambiar tema">
     <i class="bi bi-moon-fill"></i>
 </button>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/10/fotosintesis/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/2025/10/fotosintesis/index.html
@@ -22,11 +22,11 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
-                    <li class="nav-item"><a class="nav-link" href="../../../../index.html">Home</a></li>
-                    <li class="nav-item"><a class="nav-link" href="../../../../resume.html">Resumen - CV</a></li>
-                    <li class="nav-item"><a class="nav-link" href="../../../../projects.html">Proyectos</a></li>
-                    <li class="nav-item"><a class="nav-link" href="../../../../diary/">Diario de un escritor perdido</a></li>
-                    <li class="nav-item"><a class="nav-link" href="../../../../contact.html">Contacto</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../../../../index.html" data-es="Home" data-en="Home">Home</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../../../../resume.html" data-es="Resumen - CV" data-en="Resume - CV">Resumen - CV</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../../../../projects.html" data-es="Proyectos" data-en="Projects">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../../../../diary/" data-es="Diario de un escritor perdido" data-en="Diary of a lost writer">Diario de un escritor perdido</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../../../../contact.html" data-es="Contacto" data-en="Contact">Contacto</a></li>
                 </ul>
             </div>
         </div>
@@ -41,11 +41,11 @@
             <div class="row align-items-center justify-content-between flex-column flex-sm-row">
                 <div class="col-auto"><div class="small m-0">Copyright © Rick 2025</div></div>
                 <div class="col-auto">
-                    <a class="small" href="#!">Privacidad</a>
+                    <a class="small" href="#!" data-es="Privacidad" data-en="Privacy">Privacidad</a>
                     <span class="mx-1">·</span>
-                    <a class="small" href="#!">Términos</a>
+                    <a class="small" href="#!" data-es="Términos" data-en="Terms">Términos</a>
                     <span class="mx-1">·</span>
-                    <a class="small" href="#!">Contacto</a>
+                    <a class="small" href="#!" data-es="Contacto" data-en="Contact">Contacto</a>
                 </div>
             </div>
         </div>
@@ -57,7 +57,9 @@
     <script src="../../../../js/diary-utils.js"></script>
     <script src="../../../../js/diary-post.js"></script>
     <script src="../../../../js/theme-toggle.js"></script>
+    <script src="../../../../js/lang-toggle.js"></script>
 
+<button class="lang-toggle-btn" aria-label="Cambiar idioma">EN</button>
 <button class="theme-toggle-btn" aria-label="Cambiar tema">
     <i class="bi bi-moon-fill"></i>
 </button>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/diary/index.html
@@ -23,11 +23,11 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
-                    <li class="nav-item"><a class="nav-link" href="../index.html">Home</a></li>
-                    <li class="nav-item"><a class="nav-link" href="../resume.html">Resumen - CV</a></li>
-                    <li class="nav-item"><a class="nav-link" href="../projects.html">Proyectos</a></li>
-                    <li class="nav-item"><a class="nav-link" href="../diary/">Diario de un escritor perdido</a></li>
-                    <li class="nav-item"><a class="nav-link" href="../contact.html">Contacto</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../index.html" data-es="Home" data-en="Home">Home</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../resume.html" data-es="Resumen - CV" data-en="Resume - CV">Resumen - CV</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../projects.html" data-es="Proyectos" data-en="Projects">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../diary/" data-es="Diario de un escritor perdido" data-en="Diary of a lost writer">Diario de un escritor perdido</a></li>
+                    <li class="nav-item"><a class="nav-link" href="../contact.html" data-es="Contacto" data-en="Contact">Contacto</a></li>
                 </ul>
             </div>
         </div>
@@ -35,19 +35,19 @@
 
     <main class="container px-5">
         <header class="py-5 text-center">
-            <h1 class="display-5 fw-bolder diary-header"><span class="text-gradient d-inline">Diario de un escritor perdido</span></h1>
+            <h1 class="display-5 fw-bolder diary-header"><span class="text-gradient d-inline" data-es="Diario de un escritor perdido" data-en="Diary of a lost writer">Diario de un escritor perdido</span></h1>
             <p class="lead fw-normal text-muted mb-4">Pensamientos sueltos en busca de hogar.</p>
             <div class="mx-auto" style="max-width: 400px;">
-                <input type="search" id="diary-search" class="form-control" placeholder="Search..." aria-label="Buscar en el diario" />
+                <input type="search" id="diary-search" class="form-control" placeholder="Search..." aria-label="Search the diary" />
             </div>
         </header>
 
         <section id="diary-featured"></section>
         <div id="diary-list"></div>
-        <p id="diary-empty" style="display:none;color:var(--muted-text-color);">No entries found for that search.</p>
+        <p id="diary-empty" style="display:none;color:var(--muted-text-color);" data-es="No se encontraron entradas para esa búsqueda." data-en="No entries found for that search.">No entries found for that search.</p>
 
         <div class="text-center my-5">
-            <a class="diary-cta" href="../index.html">Volver al inicio</a>
+            <a class="diary-cta" href="../index.html" data-es="Volver al inicio" data-en="Back to home">Volver al inicio</a>
         </div>
     </main>
 
@@ -56,11 +56,11 @@
             <div class="row align-items-center justify-content-between flex-column flex-sm-row">
                 <div class="col-auto"><div class="small m-0">Copyright © Rick 2025</div></div>
                 <div class="col-auto">
-                    <a class="small" href="#!">Privacidad</a>
+                    <a class="small" href="#!" data-es="Privacidad" data-en="Privacy">Privacidad</a>
                     <span class="mx-1">·</span>
-                    <a class="small" href="#!">Términos</a>
+                    <a class="small" href="#!" data-es="Términos" data-en="Terms">Términos</a>
                     <span class="mx-1">·</span>
-                    <a class="small" href="#!">Contacto</a>
+                    <a class="small" href="#!" data-es="Contacto" data-en="Contact">Contacto</a>
                 </div>
             </div>
         </div>
@@ -72,7 +72,9 @@
     <script src="../js/diary-utils.js"></script>
     <script src="../js/diary-index.js"></script>
     <script src="../js/theme-toggle.js"></script>
+    <script src="../js/lang-toggle.js"></script>
 
+<button class="lang-toggle-btn" aria-label="Cambiar idioma">EN</button>
 <button class="theme-toggle-btn" aria-label="Cambiar tema">
     <i class="bi bi-moon-fill"></i>
 </button>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/gracias.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/gracias.html
@@ -100,11 +100,11 @@
                 </button>
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
-                        <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-                        <li class="nav-item"><a class="nav-link" href="resume.html">Resumen - CV</a></li>
-                        <li class="nav-item"><a class="nav-link" href="projects.html">Proyectos</a></li>
-                    <li class="nav-item"><a class="nav-link" href="diary/">Diario de un escritor perdido</a></li>
-                        <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
+                        <li class="nav-item"><a class="nav-link" href="index.html" data-es="Home" data-en="Home">Home</a></li>
+                        <li class="nav-item"><a class="nav-link" href="resume.html" data-es="Resumen - CV" data-en="Resume - CV">Resumen - CV</a></li>
+                        <li class="nav-item"><a class="nav-link" href="projects.html" data-es="Proyectos" data-en="Projects">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="diary/" data-es="Diario de un escritor perdido" data-en="Diary of a lost writer">Diario de un escritor perdido</a></li>
+                        <li class="nav-item"><a class="nav-link" href="contact.html" data-es="Contacto" data-en="Contact">Contacto</a></li>
                     </ul>
                 </div>
             </div>
@@ -118,12 +118,12 @@
                         <div class="mb-4">
                             <i class="bi bi-check-circle-fill text-primary" style="font-size: 3rem;"></i>
                         </div>
-                        <h1 class="fw-bolder">¡Gracias por contactarme!</h1>
-                        <p class="lead fw-normal text-muted">Estaré contigo en la mayor brevedad posible :)</p>
+                        <h1 class="fw-bolder" data-es="¡Gracias por contactarme!" data-en="Thank you for contacting me!">¡Gracias por contactarme!</h1>
+                        <p class="lead fw-normal text-muted" data-es="Estaré contigo en la mayor brevedad posible :)" data-en="I will get back to you as soon as possible :)">Estaré contigo en la mayor brevedad posible :)</p>
                     </div>
                     <div class="d-grid gap-3 d-sm-flex justify-content-center mt-4">
-                        <a class="btn btn-primary btn-lg px-5 py-3" href="index.html">Volver a inicio</a>
-                        <a class="btn btn-outline-dark btn-lg px-5 py-3" href="projects.html">Proyectos</a>
+                        <a class="btn btn-primary btn-lg px-5 py-3" href="index.html" data-es="Volver a inicio" data-en="Back to home">Volver a inicio</a>
+                        <a class="btn btn-outline-dark btn-lg px-5 py-3" href="projects.html" data-es="Proyectos" data-en="Projects">Proyectos</a>
                     </div>
                 </div>
             </div>
@@ -136,11 +136,11 @@
             <div class="row align-items-center justify-content-between flex-column flex-sm-row">
                 <div class="col-auto"><div class="small m-0">Copyright © Rick 2025</div></div>
                 <div class="col-auto">
-                    <a class="small" href="#!">Privacidad</a>
+                    <a class="small" href="#!" data-es="Privacidad" data-en="Privacy">Privacidad</a>
                     <span class="mx-1">·</span>
-                    <a class="small" href="#!">Términos</a>
+                    <a class="small" href="#!" data-es="Términos" data-en="Terms">Términos</a>
                     <span class="mx-1">·</span>
-                    <a class="small" href="contact.html">Contacto</a>
+                    <a class="small" href="contact.html" data-es="Contacto" data-en="Contact">Contacto</a>
                 </div>
             </div>
         </div>
@@ -150,7 +150,9 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="js/scripts.js"></script>
     <script src="js/theme-toggle.js"></script>
+    <script src="js/lang-toggle.js"></script>
 
+<button class="lang-toggle-btn" aria-label="Cambiar idioma">EN</button>
 <button class="theme-toggle-btn" aria-label="Cambiar tema">
     <i class="bi bi-moon-fill"></i>
 </button>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
@@ -245,11 +245,11 @@
                 </button>
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
-                        <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-                        <li class="nav-item"><a class="nav-link" href="resume.html">Resumen - CV</a></li>
-                        <li class="nav-item"><a class="nav-link" href="projects.html">Proyectos</a></li>
-                    <li class="nav-item"><a class="nav-link" href="diary/">Diario de un escritor perdido</a></li>
-                        <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
+                        <li class="nav-item"><a class="nav-link" href="index.html" data-es="Home" data-en="Home">Home</a></li>
+                        <li class="nav-item"><a class="nav-link" href="resume.html" data-es="Resumen - CV" data-en="Resume - CV">Resumen - CV</a></li>
+                        <li class="nav-item"><a class="nav-link" href="projects.html" data-es="Proyectos" data-en="Projects">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="diary/" data-es="Diario de un escritor perdido" data-en="Diary of a lost writer">Diario de un escritor perdido</a></li>
+                        <li class="nav-item"><a class="nav-link" href="contact.html" data-es="Contacto" data-en="Contact">Contacto</a></li>
                     </ul>
                 </div>
             </div>
@@ -263,7 +263,7 @@
                         <!-- Header text content-->
                         <div class="text-center text-xxl-start">
                             <div class="badge bg-gradient-primary-to-secondary text-white mb-4">
-                                <div class="text-uppercase">Escritor · Creativo · Editor</div>
+                                <div class="text-uppercase" data-es="Escritor · Creativo · Editor" data-en="Writer · Creative · Editor">Escritor · Creativo · Editor</div>
                             </div>
                             <div class="fs-3 fw-light text-muted">
                                 Hola, soy <strong>Rick</strong>. Periodista, creativo y amante del lenguaje
@@ -273,8 +273,8 @@
                             </h1>
 
                             <div class="d-grid gap-3 d-sm-flex justify-content-sm-center justify-content-xxl-start mb-3">
-                                <a class="btn btn-primary btn-lg px-5 py-3 me-sm-3 fs-6 fw-bolder" href="projects.html">Proyectos</a>
-                                <a class="btn btn-outline-dark btn-lg px-5 py-3 fs-6 fw-bolder" href="resume.html">Resumen - CV</a>
+                                <a class="btn btn-primary btn-lg px-5 py-3 me-sm-3 fs-6 fw-bolder" href="projects.html" data-es="Proyectos" data-en="Projects">Proyectos</a>
+                                <a class="btn btn-outline-dark btn-lg px-5 py-3 fs-6 fw-bolder" href="resume.html" data-es="Resumen - CV" data-en="Resume - CV">Resumen - CV</a>
                             </div>
                         </div>
                     </div>
@@ -301,7 +301,7 @@
             <div class="container">
                 <div class="text-center mb-5" data-aos="fade-up">
                     <h2 class="display-5 fw-bolder text-white">
-                        <span class="text-gradient d-inline">Mis proyectos</span>
+                        <span class="text-gradient d-inline" data-es="Mis proyectos" data-en="My projects">Mis proyectos</span>
                     </h2>
                 </div>
 
@@ -363,9 +363,9 @@
 
     <section class="py-5">
         <div class="container px-5 text-center">
-            <h2 class="display-5 fw-bolder"><span class="text-gradient d-inline">Diario de un escritor perdido</span></h2>
+            <h2 class="display-5 fw-bolder"><span class="text-gradient d-inline" data-es="Diario de un escritor perdido" data-en="Diary of a lost writer">Diario de un escritor perdido</span></h2>
             <div id="diary-teaser" class="text-start mt-4"></div>
-            <a class="btn btn-outline-dark px-4 py-2 mt-4" href="diary/">Leer el diario completo</a>
+            <a class="btn btn-outline-dark px-4 py-2 mt-4" href="diary/" data-es="Leer el diario completo" data-en="Read the full diary">Leer el diario completo</a>
         </div>
     </section>
 
@@ -377,11 +377,11 @@
                     <div class="small m-0">Copyright © Rick 2025</div>
                 </div>
                 <div class="col-auto">
-                    <a class="small" href="#!">Privacidad</a>
+                    <a class="small" href="#!" data-es="Privacidad" data-en="Privacy">Privacidad</a>
                     <span class="mx-1">·</span>
-                    <a class="small" href="#!">Términos</a>
+                    <a class="small" href="#!" data-es="Términos" data-en="Terms">Términos</a>
                     <span class="mx-1">·</span>
-                    <a class="small" href="#!">Contacto</a>
+                    <a class="small" href="#!" data-es="Contacto" data-en="Contact">Contacto</a>
                 </div>
             </div>
         </div>
@@ -420,7 +420,9 @@
     <script src="js/word-cycle.js"></script>
 
     <script src="js/theme-toggle.js"></script>
+    <script src="js/lang-toggle.js"></script>
 
+<button class="lang-toggle-btn" aria-label="Cambiar idioma">EN</button>
 <button class="theme-toggle-btn" aria-label="Cambiar tema">
     <i class="bi bi-moon-fill"></i>
 </button>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/lang-toggle.js
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/js/lang-toggle.js
@@ -1,0 +1,27 @@
+const translations = {
+  // Add translations as data attributes
+};
+
+document.addEventListener("DOMContentLoaded", function () {
+  const btn = document.querySelector(".lang-toggle-btn");
+  if (!btn) return;
+
+  const savedLang = localStorage.getItem("lang") || "es";
+  applyLanguage(savedLang);
+  btn.textContent = savedLang === "es" ? "EN" : "ES";
+
+  btn.addEventListener("click", function () {
+    const currentLang = localStorage.getItem("lang") || "es";
+    const newLang = currentLang === "es" ? "en" : "es";
+    localStorage.setItem("lang", newLang);
+    applyLanguage(newLang);
+    btn.textContent = newLang === "es" ? "EN" : "ES";
+  });
+});
+
+function applyLanguage(lang) {
+  document.querySelectorAll("[data-es]").forEach(function (el) {
+    el.textContent = lang === "en" ? el.getAttribute("data-en") : el.getAttribute("data-es");
+  });
+  document.documentElement.setAttribute("lang", lang);
+}

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/kali-uchis.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/kali-uchis.html
@@ -168,11 +168,11 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
-                    <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-                    <li class="nav-item"><a class="nav-link" href="resume.html">Resumen - CV</a></li>
-                    <li class="nav-item"><a class="nav-link" href="projects.html">Proyectos</a></li>
-                    <li class="nav-item"><a class="nav-link" href="diary/">Diario de un escritor perdido</a></li>
-                    <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
+                    <li class="nav-item"><a class="nav-link" href="index.html" data-es="Home" data-en="Home">Home</a></li>
+                    <li class="nav-item"><a class="nav-link" href="resume.html" data-es="Resumen - CV" data-en="Resume - CV">Resumen - CV</a></li>
+                    <li class="nav-item"><a class="nav-link" href="projects.html" data-es="Proyectos" data-en="Projects">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="diary/" data-es="Diario de un escritor perdido" data-en="Diary of a lost writer">Diario de un escritor perdido</a></li>
+                    <li class="nav-item"><a class="nav-link" href="contact.html" data-es="Contacto" data-en="Contact">Contacto</a></li>
                 </ul>
             </div>
         </div>
@@ -223,11 +223,11 @@
         <div class="row align-items-center justify-content-between flex-column flex-sm-row">
             <div class="col-auto"><div class="small m-0">Copyright © Rick 2025</div></div>
             <div class="col-auto">
-                <a class="small" href="#!">Privacidad</a>
+                <a class="small" href="#!" data-es="Privacidad" data-en="Privacy">Privacidad</a>
                 <span class="mx-1">·</span>
-                <a class="small" href="#!">Términos</a>
+                <a class="small" href="#!" data-es="Términos" data-en="Terms">Términos</a>
                 <span class="mx-1">·</span>
-                <a class="small" href="contact.html">Contacto</a>
+                <a class="small" href="contact.html" data-es="Contacto" data-en="Contact">Contacto</a>
             </div>
         </div>
     </div>
@@ -235,7 +235,9 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="js/scripts.js"></script>
     <script src="js/theme-toggle.js"></script>
+    <script src="js/lang-toggle.js"></script>
 
+<button class="lang-toggle-btn" aria-label="Cambiar idioma">EN</button>
 <button class="theme-toggle-btn" aria-label="Cambiar tema">
     <i class="bi bi-moon-fill"></i>
 </button>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/poder-mentira.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/poder-mentira.html
@@ -145,11 +145,11 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
-                    <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-                    <li class="nav-item"><a class="nav-link" href="resume.html">Resumen - CV</a></li>
-                    <li class="nav-item"><a class="nav-link" href="projects.html">Proyectos</a></li>
-                    <li class="nav-item"><a class="nav-link" href="diary/">Diario de un escritor perdido</a></li>
-                    <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
+                    <li class="nav-item"><a class="nav-link" href="index.html" data-es="Home" data-en="Home">Home</a></li>
+                    <li class="nav-item"><a class="nav-link" href="resume.html" data-es="Resumen - CV" data-en="Resume - CV">Resumen - CV</a></li>
+                    <li class="nav-item"><a class="nav-link" href="projects.html" data-es="Proyectos" data-en="Projects">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="diary/" data-es="Diario de un escritor perdido" data-en="Diary of a lost writer">Diario de un escritor perdido</a></li>
+                    <li class="nav-item"><a class="nav-link" href="contact.html" data-es="Contacto" data-en="Contact">Contacto</a></li>
                 </ul>
             </div>
         </div>
@@ -207,11 +207,11 @@
         <div class="row align-items-center justify-content-between flex-column flex-sm-row">
             <div class="col-auto"><div class="small m-0">Copyright © Rick 2025</div></div>
             <div class="col-auto">
-                <a class="small" href="#!">Privacidad</a>
+                <a class="small" href="#!" data-es="Privacidad" data-en="Privacy">Privacidad</a>
                 <span class="mx-1">·</span>
-                <a class="small" href="#!">Términos</a>
+                <a class="small" href="#!" data-es="Términos" data-en="Terms">Términos</a>
                 <span class="mx-1">·</span>
-                <a class="small" href="contact.html">Contacto</a>
+                <a class="small" href="contact.html" data-es="Contacto" data-en="Contact">Contacto</a>
             </div>
         </div>
     </div>
@@ -220,7 +220,9 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="js/scripts.js"></script>
     <script src="js/theme-toggle.js"></script>
+    <script src="js/lang-toggle.js"></script>
 
+<button class="lang-toggle-btn" aria-label="Cambiar idioma">EN</button>
 <button class="theme-toggle-btn" aria-label="Cambiar tema">
     <i class="bi bi-moon-fill"></i>
 </button>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/projects.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/projects.html
@@ -155,11 +155,11 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
-                    <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-                    <li class="nav-item"><a class="nav-link" href="resume.html">Resumen - CV</a></li>
-                    <li class="nav-item"><a class="nav-link" href="projects.html">Proyectos</a></li>
-                    <li class="nav-item"><a class="nav-link" href="diary/">Diario de un escritor perdido</a></li>
-                    <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
+                    <li class="nav-item"><a class="nav-link" href="index.html" data-es="Home" data-en="Home">Home</a></li>
+                    <li class="nav-item"><a class="nav-link" href="resume.html" data-es="Resumen - CV" data-en="Resume - CV">Resumen - CV</a></li>
+                    <li class="nav-item"><a class="nav-link" href="projects.html" data-es="Proyectos" data-en="Projects">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="diary/" data-es="Diario de un escritor perdido" data-en="Diary of a lost writer">Diario de un escritor perdido</a></li>
+                    <li class="nav-item"><a class="nav-link" href="contact.html" data-es="Contacto" data-en="Contact">Contacto</a></li>
                 </ul>
             </div>
         </div>
@@ -168,7 +168,7 @@
    <section class="py-5">
         <div class="container px-5 mb-5">
             <div class="text-center mb-5">
-                <h1 class="display-5 fw-bolder mb-0"><span class="text-gradient d-inline">Proyectos</span></h1>
+                <h1 class="display-5 fw-bolder mb-0"><span class="text-gradient d-inline" data-es="Proyectos" data-en="Projects">Proyectos</span></h1>
             </div>
             <div class="row gx-5 justify-content-center">
                 <div class="col-lg-11 col-xl-9 col-xxl-8">
@@ -226,8 +226,8 @@
     <section class="py-5 bg-gradient-primary-to-secondary text-white">
         <div class="container px-5 my-5">
             <div class="text-center">
-                <h2 class="display-4 fw-bolder mb-4">¡Creemos algo juntos!</h2>
-                <a class="btn btn-outline-light btn-lg px-5 py-3 fs-6 fw-bolder" href="contact.html">Contáctame</a>
+                <h2 class="display-4 fw-bolder mb-4" data-es="¡Creemos algo juntos!" data-en="Let's create something together!">¡Creemos algo juntos!</h2>
+                <a class="btn btn-outline-light btn-lg px-5 py-3 fs-6 fw-bolder" href="contact.html" data-es="Contáctame" data-en="Contact me">Contáctame</a>
             </div>
         </div>
     </section>
@@ -238,11 +238,11 @@
         <div class="row align-items-center justify-content-between flex-column flex-sm-row">
             <div class="col-auto"><div class="small m-0">Copyright © Rick 2025</div></div>
             <div class="col-auto">
-                <a class="small" href="#">Privacidad</a>
+                <a class="small" href="#" data-es="Privacidad" data-en="Privacy">Privacidad</a>
                 <span class="mx-1">·</span>
-                <a class="small" href="#">Términos</a>
+                <a class="small" href="#" data-es="Términos" data-en="Terms">Términos</a>
                 <span class="mx-1">·</span>
-                <a class="small" href="#">Contacto</a>
+                <a class="small" href="#" data-es="Contacto" data-en="Contact">Contacto</a>
             </div>
         </div>
     </div>
@@ -250,7 +250,9 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="js/scripts.js"></script>
     <script src="js/theme-toggle.js"></script>
+    <script src="js/lang-toggle.js"></script>
 
+<button class="lang-toggle-btn" aria-label="Cambiar idioma">EN</button>
 <button class="theme-toggle-btn" aria-label="Cambiar tema">
     <i class="bi bi-moon-fill"></i>
 </button>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/resume.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/resume.html
@@ -149,11 +149,11 @@
                 </button>
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
-                        <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-                        <li class="nav-item"><a class="nav-link" href="resume.html">Resumen - CV</a></li>
-                        <li class="nav-item"><a class="nav-link" href="projects.html">Proyectos</a></li>
-                    <li class="nav-item"><a class="nav-link" href="diary/">Diario de un escritor perdido</a></li>
-                        <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
+                        <li class="nav-item"><a class="nav-link" href="index.html" data-es="Home" data-en="Home">Home</a></li>
+                        <li class="nav-item"><a class="nav-link" href="resume.html" data-es="Resumen - CV" data-en="Resume - CV">Resumen - CV</a></li>
+                        <li class="nav-item"><a class="nav-link" href="projects.html" data-es="Proyectos" data-en="Projects">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="diary/" data-es="Diario de un escritor perdido" data-en="Diary of a lost writer">Diario de un escritor perdido</a></li>
+                        <li class="nav-item"><a class="nav-link" href="contact.html" data-es="Contacto" data-en="Contact">Contacto</a></li>
                     </ul>
                 </div>
             </div>
@@ -161,7 +161,7 @@
         <!-- Page Content-->
         <div class="container px-5 my-5">
             <div class="text-center mb-5">
-                <h1 class="display-5 fw-bolder mb-0"><span class="text-gradient d-inline">Resumen - CV</span></h1>
+                <h1 class="display-5 fw-bolder mb-0"><span class="text-gradient d-inline" data-es="Resumen - CV" data-en="Resume - CV">Resumen - CV</span></h1>
             </div>
             <div class="row gx-5 justify-content-center">
                 <div class="col-lg-11 col-xl-9 col-xxl-8">
@@ -323,11 +323,11 @@
             <div class="row align-items-center justify-content-between flex-column flex-sm-row">
                 <div class="col-auto"><div class="small m-0">Copyright © Rick 2025</div></div>
                 <div class="col-auto">
-                    <a class="small" href="#!">Privacidad</a>
+                    <a class="small" href="#!" data-es="Privacidad" data-en="Privacy">Privacidad</a>
                     <span class="mx-1">·</span>
-                    <a class="small" href="#!">Términos</a>
+                    <a class="small" href="#!" data-es="Términos" data-en="Terms">Términos</a>
                     <span class="mx-1">·</span>
-                    <a class="small" href="#!">Contacto</a>
+                    <a class="small" href="#!" data-es="Contacto" data-en="Contact">Contacto</a>
                 </div>
             </div>
         </div>
@@ -337,7 +337,9 @@
     <!-- Core theme JS-->
     <script src="js/scripts.js"></script>
     <script src="js/theme-toggle.js"></script>
+    <script src="js/lang-toggle.js"></script>
 
+<button class="lang-toggle-btn" aria-label="Cambiar idioma">EN</button>
 <button class="theme-toggle-btn" aria-label="Cambiar tema">
     <i class="bi bi-moon-fill"></i>
 </button>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/salomon.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/salomon.html
@@ -156,11 +156,11 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
-                    <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-                    <li class="nav-item"><a class="nav-link" href="resume.html">Resumen - CV</a></li>
-                    <li class="nav-item"><a class="nav-link" href="projects.html">Proyectos</a></li>
-                    <li class="nav-item"><a class="nav-link" href="diary/">Diario de un escritor perdido</a></li>
-                    <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
+                    <li class="nav-item"><a class="nav-link" href="index.html" data-es="Home" data-en="Home">Home</a></li>
+                    <li class="nav-item"><a class="nav-link" href="resume.html" data-es="Resumen - CV" data-en="Resume - CV">Resumen - CV</a></li>
+                    <li class="nav-item"><a class="nav-link" href="projects.html" data-es="Proyectos" data-en="Projects">Proyectos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="diary/" data-es="Diario de un escritor perdido" data-en="Diary of a lost writer">Diario de un escritor perdido</a></li>
+                    <li class="nav-item"><a class="nav-link" href="contact.html" data-es="Contacto" data-en="Contact">Contacto</a></li>
                 </ul>
             </div>
         </div>
@@ -231,11 +231,11 @@
                 <div class="small m-0">Copyright © Rick 2025</div>
             </div>
             <div class="col-auto">
-                <a class="small" href="#!">Privacidad</a>
+                <a class="small" href="#!" data-es="Privacidad" data-en="Privacy">Privacidad</a>
                 <span class="mx-1">·</span>
-                <a class="small" href="#!">Términos</a>
+                <a class="small" href="#!" data-es="Términos" data-en="Terms">Términos</a>
                 <span class="mx-1">·</span>
-                <a class="small" href="#!">Contacto</a>
+                <a class="small" href="#!" data-es="Contacto" data-en="Contact">Contacto</a>
             </div>
         </div>
     </div>
@@ -250,7 +250,9 @@
 
 
     <script src="js/theme-toggle.js"></script>
+    <script src="js/lang-toggle.js"></script>
 
+<button class="lang-toggle-btn" aria-label="Cambiar idioma">EN</button>
 <button class="theme-toggle-btn" aria-label="Cambiar tema">
     <i class="bi bi-moon-fill"></i>
 </button>


### PR DESCRIPTION
### Motivation
- Provide a one-click language toggle so the statically authored site (currently Spanish) can be viewed in English without changing templates or rebuilding content. 
- Translate only static HTML content using a simple `data-es` / `data-en` attribute system while leaving dynamic JS-driven content untouched. 

### Description
- Add `js/lang-toggle.js` which reads/writes `localStorage` for the `lang` preference, toggles the button label, applies content swaps from `data-es`/`data-en` and updates the document `lang` attribute. 
- Add a circular language toggle button (`.lang-toggle-btn`) to every page immediately before the existing theme toggle and load `js/lang-toggle.js` on every page directly after `theme-toggle.js`, using correct relative paths for diary pages. 
- Add `data-es` and `data-en` attributes to shared static UI text (navigation items, key CTAs, selected section headers, footer links and other visible labels) across site pages including `index.html`, `projects.html`, `contact.html`, `resume.html`, diary pages and project article pages. 
- Add the requested styling block for `.lang-toggle-btn` to `css/styles.css` implementing fixed positioning, hover/dark-mode states and responsive sizing. 

### Testing
- Ran `git diff --check` which returned clean (no whitespace/error issues). 
- Executed a local Python verification script to scan target HTML files and confirm each updated page includes both the `.lang-toggle-btn` and a `lang-toggle.js` script tag, and the check passed. 
- Verified that `lang-toggle.js` and the new CSS block are present in `js/lang-toggle.js` and `css/styles.css` respectively, and that pages reference the script with proper relative paths; these automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee79124188324af7c25f3cf056253)