### PR TITLE
feat: add Foro as featured project on oranrick.com

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -2113,3 +2113,118 @@ figure.article-img-wide figcaption {
   .cv-entry { padding: 1rem 0.85rem; }
   .cv-entry-meta { gap: 0.3rem 0.5rem; }
 }
+
+/* ═══════════════════════════════════════════════════════════
+   Projects page — Foro featured card visual side
+   ═══════════════════════════════════════════════════════════ */
+
+.foro-feat-vis {
+  background: rgba(184, 105, 73, 0.06);
+  border-right: 1px solid rgba(184, 105, 73, 0.18);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 2.5rem 2.75rem;
+  position: relative;
+  overflow: hidden;
+  min-height: 280px;
+  gap: 1.5rem;
+}
+
+.foro-feat-bg-word {
+  position: absolute;
+  bottom: -1rem;
+  right: -0.5rem;
+  font-family: 'Barlow Condensed', sans-serif;
+  font-size: 9rem;
+  font-weight: 800;
+  color: rgba(184, 105, 73, 0.07);
+  letter-spacing: -0.06em;
+  line-height: 1;
+  pointer-events: none;
+  user-select: none;
+}
+
+.foro-feat-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  position: relative;
+  z-index: 1;
+}
+
+.foro-feat-logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.foro-feat-logo-text {
+  font-family: 'Syne', sans-serif;
+  font-size: 1.9rem;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  color: var(--text-color);
+  line-height: 1;
+}
+
+.foro-feat-tagline {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(184, 105, 73, 0.85);
+}
+
+.foro-feat-articles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  position: relative;
+  z-index: 1;
+  width: 100%;
+}
+
+.foro-feat-article {
+  padding-left: 0.7rem;
+  border-left: 2px solid rgba(184, 105, 73, 0.3);
+}
+
+.foro-feat-seccion {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(184, 105, 73, 0.75);
+  display: block;
+  margin-bottom: 2px;
+}
+
+.foro-feat-titulo {
+  font-family: 'Syne', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-color);
+  line-height: 1.3;
+  display: block;
+}
+
+.foro-feat-label-bottom {
+  position: absolute;
+  bottom: 1.25rem;
+  left: 2.75rem;
+  z-index: 1;
+}
+
+@media (max-width: 768px) {
+  .foro-feat-vis {
+    padding: 1.5rem 1.25rem 2.5rem;
+    border-right: none;
+    border-bottom: 1px solid rgba(184, 105, 73, 0.18);
+    min-height: 200px;
+    gap: 1rem;
+  }
+  .foro-feat-bg-word { font-size: 6rem; }
+  .foro-feat-label-bottom { left: 1.25rem; }
+}

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
@@ -204,7 +204,16 @@
 
                 <div class="projects-grid">
 
-                    <a href="arte-naturaleza.html" class="project-card-new" data-aos="fade-up" data-aos-delay="0">
+                    <a href="https://foro-red.vercel.app" target="_blank" rel="noopener noreferrer" class="project-card-new project-card-text" data-aos="fade-up" data-aos-delay="0">
+                        <div class="card-body-inner">
+                            <span class="card-tag" data-es="Proyecto · Periodismo · IA" data-en="Project · Journalism · AI">Proyecto · Periodismo · IA</span>
+                            <h3 data-es="foro" data-en="foro">foro</h3>
+                            <p data-es="Un medio que mide el lenguaje político. Verificación, análisis de discurso e Índice de Resonancia Afectiva." data-en="A publication that measures political language. Fact-checking, discourse analysis and Affective Resonance Index.">Un medio que mide el lenguaje político. Verificación, análisis de discurso e Índice de Resonancia Afectiva.</p>
+                            <span class="card-arrow">→</span>
+                        </div>
+                    </a>
+
+                    <a href="arte-naturaleza.html" class="project-card-new" data-aos="fade-up" data-aos-delay="60">
                         <div class="card-img-wrap">
                             <img src="assets/portadaarte.jpg" alt="Arte y naturaleza">
                         </div>
@@ -215,7 +224,7 @@
                         </div>
                     </a>
 
-                    <a href="poder-mentira.html" class="project-card-new" data-aos="fade-up" data-aos-delay="60">
+                    <a href="poder-mentira.html" class="project-card-new" data-aos="fade-up" data-aos-delay="120">
                         <div class="card-img-wrap">
                             <img src="assets/trump.jpg" alt="La política del engaño">
                         </div>
@@ -226,7 +235,7 @@
                         </div>
                     </a>
 
-                    <a href="salomon.html" class="project-card-new" data-aos="fade-up" data-aos-delay="120">
+                    <a href="salomon.html" class="project-card-new" data-aos="fade-up" data-aos-delay="180">
                         <div class="card-img-wrap">
                             <img src="assets/portada-salo.jpg" alt="La abnegación más pura">
                         </div>
@@ -237,7 +246,7 @@
                         </div>
                     </a>
 
-                    <a href="kali-uchis.html" class="project-card-new" data-aos="fade-up" data-aos-delay="180">
+                    <a href="kali-uchis.html" class="project-card-new" data-aos="fade-up" data-aos-delay="240">
                         <div class="card-img-wrap">
                             <img src="assets/sincerely.jpg" alt="Amor, duelo y libertad">
                         </div>
@@ -248,7 +257,7 @@
                         </div>
                     </a>
 
-                    <a href="diary/" class="project-card-new project-card-text" data-aos="fade-up" data-aos-delay="240">
+                    <a href="diary/" class="project-card-new project-card-text" data-aos="fade-up" data-aos-delay="300">
                         <div class="card-body-inner">
                             <span class="card-tag">Diario</span>
                             <h3 data-es="Diario de un escritor perdido" data-en="Diary of a lost writer">Diario de un escritor perdido</h3>
@@ -257,7 +266,7 @@
                         </div>
                     </a>
 
-                    <a href="resume.html" class="project-card-new project-card-text" data-aos="fade-up" data-aos-delay="300">
+                    <a href="resume.html" class="project-card-new project-card-text" data-aos="fade-up" data-aos-delay="360">
                         <div class="card-body-inner">
                             <span class="card-tag">CV</span>
                             <h3 data-es="Resumen &amp; CV" data-en="Resume &amp; CV">Resumen &amp; CV</h3>
@@ -266,7 +275,7 @@
                         </div>
                     </a>
 
-                    <a href="contact.html" class="project-card-new project-card-text" data-aos="fade-up" data-aos-delay="360">
+                    <a href="contact.html" class="project-card-new project-card-text" data-aos="fade-up" data-aos-delay="420">
                         <div class="card-body-inner">
                             <span class="card-tag">Contacto</span>
                             <h3 data-es="Hablemos" data-en="Let's talk">Hablemos</h3>

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/projects.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/projects.html
@@ -110,6 +110,67 @@
         </div>
     </section>
 
+    <!-- Foro Featured -->
+    <section class="pb-4">
+        <div class="container px-5">
+            <a href="https://foro-red.vercel.app" target="_blank" rel="noopener noreferrer"
+               class="project-featured-card" data-aos="fade-up">
+
+                <!-- Visual side -->
+                <div class="project-featured-img foro-feat-vis">
+                    <div class="foro-feat-bg-word">foro</div>
+                    <div class="foro-feat-header">
+                        <div class="foro-feat-logo">
+                            <svg width="38" height="20" viewBox="0 0 76 40" fill="none" aria-hidden="true">
+                                <circle cx="22" cy="20" r="17" stroke="rgba(240,240,240,0.7)" stroke-width="3"/>
+                                <circle cx="42" cy="20" r="17" stroke="rgba(240,240,240,0.7)" stroke-width="3"/>
+                            </svg>
+                            <span class="foro-feat-logo-text">foro</span>
+                        </div>
+                        <span class="foro-feat-tagline">Un lugar para hablar</span>
+                    </div>
+                    <div class="foro-feat-articles">
+                        <div class="foro-feat-article">
+                            <span class="foro-feat-seccion">Política · IRA 5.4</span>
+                            <span class="foro-feat-titulo">Sánchez declara el «no a la guerra» ante la crisis en Oriente Medio</span>
+                        </div>
+                        <div class="foro-feat-article">
+                            <span class="foro-feat-seccion">Política · IRA 2.8</span>
+                            <span class="foro-feat-titulo">Feijóo presenta la moción de censura con un discurso de máxima intensidad retórica</span>
+                        </div>
+                        <div class="foro-feat-article">
+                            <span class="foro-feat-seccion">Ciencia</span>
+                            <span class="foro-feat-titulo">El Mediterráneo se calienta tres veces más rápido que la media global</span>
+                        </div>
+                    </div>
+                    <div class="foro-feat-label-bottom">
+                        <span class="ira-feat-url">foro-red.vercel.app ↗</span>
+                    </div>
+                </div>
+
+                <!-- Text side -->
+                <div class="project-featured-body">
+                    <span class="card-tag">Proyecto · Periodismo · IA</span>
+                    <h2 style="font-size:clamp(2.2rem,4vw,3.5rem);letter-spacing:-0.04em;">foro</h2>
+                    <p style="font-family:'DM Mono',monospace;font-size:0.75rem;color:rgba(184,105,73,0.85);letter-spacing:0.06em;margin:0;">
+                        Periodismo que mide el lenguaje
+                    </p>
+                    <p style="margin-top:0.75rem;">
+                        Un medio que no solo informa sobre el discurso político — lo mide, lo verifica y lo traduce. Cada artículo aplica el Índice de Resonancia Afectiva: ocho dimensiones del lenguaje que sitúan al político entre la polarización y la empatía.
+                    </p>
+                    <div style="display:flex;gap:0.5rem;flex-wrap:wrap;margin-top:0.25rem;">
+                        <span class="tech-tag">Next.js</span>
+                        <span class="tech-tag">Sanity CMS</span>
+                        <span class="tech-tag">Claude API</span>
+                        <span class="tech-tag">Vercel</span>
+                    </div>
+                    <span class="card-readmore" style="margin-top:0.75rem;" data-es="Explorar proyecto →" data-en="Explore project →">Explorar proyecto →</span>
+                </div>
+
+            </a>
+        </div>
+    </section>
+
     <!-- Articles grid -->
     <section class="projects-section pb-5">
         <div class="container px-5">


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **projects.html**: Adds a new featured card for Foro (`foro-red.vercel.app`) between the IRA Index card and the essays grid. The visual side shows the two-circle brand mark, real article headlines with IRA scores (Sánchez 5.4, Feijóo 2.8), and a terracotta accent that echoes Foro's editorial palette.
- **index.html**: Inserts a Foro card as the first item in the "Más proyectos" grid, linking externally to the Foro deployment.
- **styles.css**: New `.foro-feat-vis` and related utility classes for the card's data-viz side. Responsive — collapses to a stacked layout on mobile matching the existing IRA card pattern.

## Test plan

- [ ] Open `projects.html` locally and confirm the Foro card appears between IRA and the essays section
- [ ] Open `index.html` locally and confirm Foro is the first card in "Más proyectos"
- [ ] Resize to mobile (≤768px) and verify the Foro card visual side stacks correctly above the text body
- [ ] Verify the EN/ES language toggle still works on the new card's `data-es`/`data-en` attributes
- [ ] Click the card — should open `https://foro-red.vercel.app` in a new tab

https://claude.ai/code/session_01Dj6h79yrGXZu93rafhoGXJ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dj6h79yrGXZu93rafhoGXJ)_