### PR TITLE
feat: Foro hero slide as cream editorial window

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -2158,73 +2158,167 @@ figure.article-img-wide figcaption {
   transform: scale(1.3);
 }
 
-/* Foro hero card */
-.foro-hero-card {
-  border-color: rgba(184, 105, 73, 0.22);
-  border-left-color: rgba(184, 105, 73, 0.85);
-  background: rgba(184, 105, 73, 0.04);
+/* ── Foro window card (hero slide 2) ─────────────────────── */
+
+.foro-window-card {
+  display: block;
+  background: #f1ebe0;
+  border-radius: 16px;
+  padding: 1.75rem 2rem;
+  color: #16140f;
+  text-decoration: none;
+  box-shadow: 0 10px 48px rgba(0, 0, 0, 0.45), 0 2px 8px rgba(0, 0, 0, 0.25);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
-.foro-hero-card:hover {
-  border-color: rgba(184, 105, 73, 0.42);
-  box-shadow: 0 20px 56px rgba(184, 105, 73, 0.12);
-  background: rgba(184, 105, 73, 0.07);
-  color: var(--text-color);
+.foro-window-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.5), 0 4px 12px rgba(0, 0, 0, 0.3);
+  color: #16140f;
+  text-decoration: none;
 }
 
-.foro-hero-card .ira-card-cta {
-  color: rgba(184, 105, 73, 0.9);
-  border-bottom-color: rgba(184, 105, 73, 0.3);
-}
-
-.foro-hero-card:hover .ira-card-cta {
-  border-bottom-color: rgba(184, 105, 73, 0.8);
-}
-
-.foro-hero-articles {
+.foro-win-masthead {
   display: flex;
-  flex-direction: column;
-  gap: 0.7rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--border-color);
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
 }
 
-.foro-hero-article {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  grid-template-rows: auto auto;
-  column-gap: 0.5rem;
-  align-items: baseline;
-}
-
-.foro-hero-meta {
+.foro-win-logo {
   display: flex;
-  align-items: baseline;
-  gap: 0.4rem;
-  grid-column: 1 / -1;
-  margin-bottom: 2px;
+  align-items: center;
+  gap: 10px;
 }
 
-.foro-hero-seccion {
+.foro-win-name {
+  font-family: 'Instrument Serif', Georgia, serif;
+  font-size: 2rem;
+  letter-spacing: -0.03em;
+  color: #16140f;
+  line-height: 1;
+}
+
+.foro-win-url {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.58rem;
+  color: #9e9b95;
+  letter-spacing: 0.04em;
+}
+
+.foro-win-rule {
+  border: none;
+  border-top: 1px solid #d8d0c4;
+  margin: 0.65rem 0;
+}
+
+.foro-win-tagline {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #b86949;
+  margin: 0;
+}
+
+.foro-win-lead {
+  padding: 0.5rem 0 0.25rem;
+}
+
+.foro-win-lead-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.5rem;
+}
+
+.foro-win-seccion {
   font-family: 'DM Mono', monospace;
   font-size: 0.6rem;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: rgba(184, 105, 73, 0.7);
+  letter-spacing: 0.14em;
+  color: #6b6860;
 }
 
-.foro-hero-ira {
+.foro-win-ira-badge {
   font-family: 'DM Mono', monospace;
-  font-size: 0.6rem;
+  font-size: 0.58rem;
   font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: rgba(184, 105, 73, 0.12);
 }
 
-.foro-hero-titulo {
-  font-family: 'Syne', sans-serif;
-  font-size: 0.82rem;
-  color: var(--text-color);
+.foro-win-titulo-lead {
+  font-family: 'Instrument Serif', Georgia, serif;
+  font-size: clamp(1.1rem, 2.2vw, 1.45rem);
+  font-weight: 400;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: #16140f;
+  margin: 0 0 0.4rem;
+}
+
+.foro-win-subtitulo {
+  font-family: 'EB Garamond', Georgia, serif;
+  font-size: 0.9rem;
+  color: #3a3830;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.foro-win-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0 1.25rem;
+  padding: 0.5rem 0 0.25rem;
+}
+
+.foro-win-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.foro-win-titulo-sm {
+  font-family: 'EB Garamond', Georgia, serif;
+  font-size: 0.88rem;
+  color: #16140f;
   line-height: 1.35;
-  grid-column: 1 / -1;
+}
+
+.foro-win-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 0.1rem;
+}
+
+.foro-win-stack {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.58rem;
+  color: #9e9b95;
+  letter-spacing: 0.04em;
+}
+
+.foro-win-cta {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: #b86949;
+  transition: letter-spacing 0.2s;
+}
+
+.foro-window-card:hover .foro-win-cta {
+  letter-spacing: 0.1em;
+}
+
+@media (max-width: 767px) {
+  .foro-win-grid { grid-template-columns: 1fr 1fr; }
+  .foro-win-item:last-child { display: none; }
+  .foro-win-titulo-lead { font-size: 1.1rem; }
 }
 
 /* ═══════════════════════════════════════════════════════════

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
@@ -18,7 +18,7 @@
     <link rel="icon" type="image/x-icon" href="assets/orange.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;500;600;700;800&family=DM+Mono:ital,wght@0,400;0,500;1,400&family=Barlow+Condensed:wght@700;800&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;500;600;700;800&family=DM+Mono:ital,wght@0,400;0,500;1,400&family=Barlow+Condensed:wght@700;800&family=Instrument+Serif:ital@0;1&family=EB+Garamond:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css" rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" />
     <link href="css/styles.css" rel="stylesheet" />
@@ -194,59 +194,62 @@
                         </a>
                         </div><!-- /slide 1 -->
 
-                        <!-- Slide 2: foro -->
+                        <!-- Slide 2: foro — ventana editorial -->
                         <div class="hero-slide">
-                        <a href="https://foro-red.vercel.app" target="_blank" rel="noopener noreferrer" class="ira-hero-card foro-hero-card">
-                            <div class="d-flex align-items-start justify-content-between mb-3">
-                                <span class="card-tag" data-es="Proyecto destacado" data-en="Featured project">Proyecto destacado</span>
-                                <span class="ira-external-hint">foro-red.vercel.app ↗</span>
+                        <a href="https://foro-red.vercel.app" target="_blank" rel="noopener noreferrer" class="foro-window-card">
+
+                            <!-- Masthead -->
+                            <div class="foro-win-masthead">
+                                <div class="foro-win-logo">
+                                    <svg width="36" height="18" viewBox="0 0 72 36" fill="none" aria-hidden="true">
+                                        <circle cx="20" cy="18" r="16" stroke="#16140f" stroke-width="2.5"/>
+                                        <circle cx="42" cy="18" r="16" stroke="#16140f" stroke-width="2.5"/>
+                                    </svg>
+                                    <span class="foro-win-name">foro</span>
+                                </div>
+                                <span class="foro-win-url">foro-red.vercel.app ↗</span>
                             </div>
 
-                            <div class="d-flex align-items-center gap-3 mb-1">
-                                <svg width="34" height="18" viewBox="0 0 68 36" fill="none" aria-hidden="true">
-                                    <circle cx="19" cy="18" r="15" stroke="rgba(240,240,240,0.75)" stroke-width="2.5"/>
-                                    <circle cx="39" cy="18" r="15" stroke="rgba(240,240,240,0.75)" stroke-width="2.5"/>
-                                </svg>
-                                <h2 class="ira-card-title" style="margin:0">foro</h2>
+                            <div class="foro-win-rule"></div>
+                            <p class="foro-win-tagline">Periodismo que mide el lenguaje · Madrid, 2026</p>
+                            <div class="foro-win-rule"></div>
+
+                            <!-- Artículo principal -->
+                            <div class="foro-win-lead">
+                                <div class="foro-win-lead-meta">
+                                    <span class="foro-win-seccion">Política</span>
+                                    <span class="foro-win-ira-badge" style="color:#9a5a30">IRA 5.4</span>
+                                </div>
+                                <h3 class="foro-win-titulo-lead">Sánchez declara el «no a la guerra» ante la crisis en Oriente Medio</h3>
+                                <p class="foro-win-subtitulo">El presidente apela a la memoria de Irak y desmarca a España de la respuesta militar occidental.</p>
                             </div>
-                            <p class="ira-card-subtitle" style="color:rgba(184,105,73,0.9)">Un lugar para hablar</p>
 
-                            <p class="ira-card-desc" data-es="Un medio que mide el lenguaje político. Verificación, análisis de discurso e Índice de Resonancia Afectiva." data-en="A publication that measures political language. Fact-checking, discourse analysis and IRA score.">Un medio que mide el lenguaje político. Verificación, análisis de discurso e Índice de Resonancia Afectiva.</p>
+                            <div class="foro-win-rule"></div>
 
-                            <div class="foro-hero-articles">
-                                <div class="foro-hero-article">
-                                    <div class="foro-hero-meta">
-                                        <span class="foro-hero-seccion">Política</span>
-                                        <span class="foro-hero-ira" style="color:#e8a838">· IRA 5.4</span>
-                                    </div>
-                                    <span class="foro-hero-titulo">Sánchez declara el «no a la guerra» ante la crisis en Oriente Medio</span>
+                            <!-- Artículos secundarios -->
+                            <div class="foro-win-grid">
+                                <div class="foro-win-item">
+                                    <span class="foro-win-seccion">Política · <span style="color:#b05a40">IRA 2.8</span></span>
+                                    <span class="foro-win-titulo-sm">Feijóo presenta la moción de censura con máxima intensidad retórica</span>
                                 </div>
-                                <div class="foro-hero-article">
-                                    <div class="foro-hero-meta">
-                                        <span class="foro-hero-seccion">Política</span>
-                                        <span class="foro-hero-ira" style="color:#e05252">· IRA 2.8</span>
-                                    </div>
-                                    <span class="foro-hero-titulo">Feijóo presenta la moción de censura con máxima intensidad retórica</span>
+                                <div class="foro-win-item">
+                                    <span class="foro-win-seccion">Ciencia</span>
+                                    <span class="foro-win-titulo-sm">El Mediterráneo se calienta tres veces más rápido que la media global</span>
                                 </div>
-                                <div class="foro-hero-article">
-                                    <div class="foro-hero-meta">
-                                        <span class="foro-hero-seccion">Ciencia</span>
-                                    </div>
-                                    <span class="foro-hero-titulo">El Mediterráneo se calienta tres veces más rápido que la media global</span>
+                                <div class="foro-win-item">
+                                    <span class="foro-win-seccion">Tecnología</span>
+                                    <span class="foro-win-titulo-sm">La desinformación generada por IA se multiplicó por cuatro en las últimas elecciones</span>
                                 </div>
                             </div>
 
-                            <div class="d-flex align-items-center justify-content-between mt-4">
-                                <div class="ira-tech-stack">
-                                    <span class="tech-tag">Next.js</span>
-                                    <span class="tech-tag">Sanity CMS</span>
-                                    <span class="tech-tag">Claude API</span>
-                                </div>
-                                <span class="ira-card-cta">
-                                    <span data-es="Ver proyecto" data-en="View project">Ver proyecto</span>
-                                    <span class="cta-arrow">→</span>
-                                </span>
+                            <div class="foro-win-rule"></div>
+
+                            <!-- Footer -->
+                            <div class="foro-win-footer">
+                                <span class="foro-win-stack">Next.js · Sanity CMS · Claude API</span>
+                                <span class="foro-win-cta" data-es="Abrir publicación →" data-en="Open publication →">Abrir publicación →</span>
                             </div>
+
                         </a>
                         </div><!-- /slide 2 -->
 


### PR DESCRIPTION
Redesigns the Foro hero slide so it has its own visual identity instead of cloning IRA's dark style.

**Before:** dark card with orange hints, too similar to IRA  
**After:** cream `#f1ebe0` "window" floating on the dark background — Instrument Serif masthead, EB Garamond article titles, terracotta IRA score badges, three-column article grid

Each project now looks completely different from the other: IRA is dark/data-viz, Foro is light/editorial. The contrast makes both more striking.

https://claude.ai/code/session_01Dj6h79yrGXZu93rafhoGXJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dj6h79yrGXZu93rafhoGXJ)_