### PR TITLE
Add IRA Index and foro project buttons to navbar

### DIFF
--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/css/styles.css
@@ -2435,3 +2435,52 @@ figure.article-img-wide figcaption {
   .foro-feat-bg-word { font-size: 6rem; }
   .foro-feat-label-bottom { left: 1.25rem; }
 }
+
+/* ---- Project nav buttons (IRA Index + foro) ---- */
+.proj-btns {
+  display: flex;
+  gap: 0.5rem;
+  margin-left: 1rem;
+  align-items: center;
+}
+
+.proj-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.28rem 0.72rem;
+  border-radius: 5px;
+  font-size: 0.68rem;
+  text-decoration: none;
+  transition: all 0.2s;
+  white-space: nowrap;
+  line-height: 1.2;
+}
+
+.proj-btn-ira {
+  font-family: 'DM Mono', monospace;
+  letter-spacing: 0.04em;
+  background: rgba(255, 102, 0, 0.07);
+  border: 1px solid rgba(255, 102, 0, 0.38);
+  color: var(--accent);
+}
+.proj-btn-ira:hover {
+  background: rgba(255, 102, 0, 0.15);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.proj-btn-foro {
+  font-family: 'Instrument Serif', Georgia, serif;
+  font-size: 0.88rem;
+  background: #f1ebe0;
+  border: 1px solid #d8d0c4;
+  color: #b86949;
+}
+.proj-btn-foro:hover {
+  background: #e8e0d0;
+  color: #9a5a30;
+}
+
+@media (max-width: 991px) {
+  .proj-btns { margin-left: 0; margin-top: 0.75rem; }
+}

--- a/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
+++ b/startbootstrap-personal-gh-pages/startbootstrap-personal-gh-pages/index.html
@@ -44,6 +44,10 @@
                         <li class="nav-item"><a class="nav-link" href="diary/" data-es="Diario" data-en="Diary">Diario</a></li>
                         <li class="nav-item"><a class="nav-link" href="contact.html" data-es="Contacto" data-en="Contact">Contacto</a></li>
                     </ul>
+                    <div class="proj-btns">
+                        <a href="https://ira-index.vercel.app" target="_blank" rel="noopener noreferrer" class="proj-btn proj-btn-ira">IRA Index ↗</a>
+                        <a href="https://foro-red.vercel.app" target="_blank" rel="noopener noreferrer" class="proj-btn proj-btn-foro">foro ↗</a>
+                    </div>
                 </div>
             </div>
         </nav>
@@ -74,12 +78,8 @@
                         </div>
                     </div>
 
-                    <!-- Right: hero project slider -->
+                    <!-- Right: IRA featured card -->
                     <div class="col-lg-7 mt-5 mt-lg-0" data-aos="fade-left" data-aos-duration="700" data-aos-delay="100">
-                      <div class="hero-slider">
-
-                        <!-- Slide 1: IRA Index -->
-                        <div class="hero-slide active">
                         <a href="https://ira-index.vercel.app" target="_blank" rel="noopener noreferrer" class="ira-hero-card">
                             <div class="d-flex align-items-start justify-content-between mb-3">
                                 <span class="card-tag" data-es="Proyecto destacado" data-en="Featured project">Proyecto destacado</span>
@@ -192,74 +192,6 @@
                                 </span>
                             </div>
                         </a>
-                        </div><!-- /slide 1 -->
-
-                        <!-- Slide 2: foro — ventana editorial -->
-                        <div class="hero-slide">
-                        <a href="https://foro-red.vercel.app" target="_blank" rel="noopener noreferrer" class="foro-window-card">
-
-                            <!-- Masthead -->
-                            <div class="foro-win-masthead">
-                                <div class="foro-win-logo">
-                                    <svg width="36" height="18" viewBox="0 0 72 36" fill="none" aria-hidden="true">
-                                        <circle cx="20" cy="18" r="16" stroke="#16140f" stroke-width="2.5"/>
-                                        <circle cx="42" cy="18" r="16" stroke="#16140f" stroke-width="2.5"/>
-                                    </svg>
-                                    <span class="foro-win-name">foro</span>
-                                </div>
-                                <span class="foro-win-url">foro-red.vercel.app ↗</span>
-                            </div>
-
-                            <div class="foro-win-rule"></div>
-                            <p class="foro-win-tagline">Periodismo que mide el lenguaje · Madrid, 2026</p>
-                            <div class="foro-win-rule"></div>
-
-                            <!-- Artículo principal -->
-                            <div class="foro-win-lead">
-                                <div class="foro-win-lead-meta">
-                                    <span class="foro-win-seccion">Política</span>
-                                    <span class="foro-win-ira-badge" style="color:#9a5a30">IRA 5.4</span>
-                                </div>
-                                <h3 class="foro-win-titulo-lead">Sánchez declara el «no a la guerra» ante la crisis en Oriente Medio</h3>
-                                <p class="foro-win-subtitulo">El presidente apela a la memoria de Irak y desmarca a España de la respuesta militar occidental.</p>
-                            </div>
-
-                            <div class="foro-win-rule"></div>
-
-                            <!-- Artículos secundarios -->
-                            <div class="foro-win-grid">
-                                <div class="foro-win-item">
-                                    <span class="foro-win-seccion">Política · <span style="color:#b05a40">IRA 2.8</span></span>
-                                    <span class="foro-win-titulo-sm">Feijóo presenta la moción de censura con máxima intensidad retórica</span>
-                                </div>
-                                <div class="foro-win-item">
-                                    <span class="foro-win-seccion">Ciencia</span>
-                                    <span class="foro-win-titulo-sm">El Mediterráneo se calienta tres veces más rápido que la media global</span>
-                                </div>
-                                <div class="foro-win-item">
-                                    <span class="foro-win-seccion">Tecnología</span>
-                                    <span class="foro-win-titulo-sm">La desinformación generada por IA se multiplicó por cuatro en las últimas elecciones</span>
-                                </div>
-                            </div>
-
-                            <div class="foro-win-rule"></div>
-
-                            <!-- Footer -->
-                            <div class="foro-win-footer">
-                                <span class="foro-win-stack">Next.js · Sanity CMS · Claude API</span>
-                                <span class="foro-win-cta" data-es="Abrir publicación →" data-en="Open publication →">Abrir publicación →</span>
-                            </div>
-
-                        </a>
-                        </div><!-- /slide 2 -->
-
-                      </div><!-- /hero-slider -->
-
-                      <!-- Dots navigation -->
-                      <div class="hero-dots" role="group" aria-label="Proyectos destacados">
-                          <button class="hero-dot active" aria-label="IRA Index"></button>
-                          <button class="hero-dot" aria-label="foro"></button>
-                      </div>
                     </div>
 
                 </div>
@@ -393,36 +325,6 @@
     <script src="js/diary-teaser.js"></script>
     <script src="js/word-cycle.js"></script>
     <script src="js/lang-toggle.js"></script>
-    <script>
-    (function () {
-      var slides = document.querySelectorAll('.hero-slide');
-      var dots   = document.querySelectorAll('.hero-dot');
-      var current = 0;
-      var timer;
-
-      function goTo(i) {
-        slides[current].classList.remove('active');
-        dots[current].classList.remove('active');
-        current = i;
-        slides[current].classList.add('active');
-        dots[current].classList.add('active');
-      }
-
-      function next() { goTo((current + 1) % slides.length); }
-
-      function start() { timer = setInterval(next, 5000); }
-
-      dots.forEach(function (dot, i) {
-        dot.addEventListener('click', function () {
-          clearInterval(timer);
-          goTo(i);
-          start();
-        });
-      });
-
-      start();
-    })();
-    </script>
 
     <button class="lang-toggle-btn" aria-label="Cambiar idioma">EN</button>
 </body>


### PR DESCRIPTION
## Summary

- Removes Foro from the home hero; IRA Index is restored as the sole hero card
- Adds two small styled buttons to the navbar, after the nav links:
  - **IRA Index ↗** — DM Mono font, orange border on dark background (matches oranrick.com aesthetic)
  - **foro ↗** — Instrument Serif font, cream `#f1ebe0` background with terracotta `#b86949` text (matches Foro publication aesthetic)
- Each button links to its live site (`ira-index.vercel.app` and `foro-red.vercel.app`)
- Collapses into the mobile menu on small screens

## Test plan

- [ ] Navbar shows both buttons on desktop to the right of the nav links
- [ ] IRA Index button is orange-tinted (dark bg, orange border/text)
- [ ] foro button is cream/terracotta styled
- [ ] Both buttons open the correct URLs in a new tab
- [ ] On mobile (`< 992px`), buttons appear below the nav links when menu is open
- [ ] Home hero still shows the IRA card only (no Foro slide)

https://claude.ai/code/session_01Dj6h79yrGXZu93rafhoGXJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dj6h79yrGXZu93rafhoGXJ)_